### PR TITLE
Make possible to define DVER in Config.mak

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -95,7 +95,7 @@ COLOR_OUT ?= $(COLOR_ERR)
 # To compile the D2 version, you can use make DVER=2
 # FIXME_IN_D2: This is only present as a transitional solution, it should be
 # removed after the D2 migration is done
-DVER := 1
+DVER ?= 1
 export MAKD_DVER := $(DVER)
 
 # Default D compiler (tries first with dmd1 and uses dmd if not present)

--- a/README.rst
+++ b/README.rst
@@ -304,6 +304,11 @@ differently in D1 and D2, for example:
         rule: d2_file.d
         endif
 
+To make project always use D2 compiler, simply define this variable in
+``Config.mak``:
+
+        DVER:=2
+
 Variables you might want to override
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * The special target variables ``all``, ``test``, ``doc``.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,8 @@ New Features
   If ``UnitTestRunner.d`` module is neither found not explicitly
   configured by developer, makd will resort to using default D test
   runner instead.
+
+* ``Makd.mak``
+
+  Now `DVER` variable is set only if it was not already defined,
+  allow to put it into `Config.makd` for D2-only projects.


### PR DESCRIPTION
It makes no sense for D2 only projects to force passing
`DVER=2` argument to command line each time explicitly.
