### PR TITLE
Support nested submodules

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -95,7 +95,7 @@ COLOR_OUT ?= $(COLOR_ERR)
 # To compile the D2 version, you can use make DVER=2
 # FIXME_IN_D2: This is only present as a transitional solution, it should be
 # removed after the D2 migration is done
-DVER := 1
+DVER ?= 1
 export MAKD_DVER := $(DVER)
 
 # Default D compiler (tries first with dmd1 and uses dmd if not present)

--- a/Makd.mak
+++ b/Makd.mak
@@ -461,13 +461,14 @@ UNITTEST_FILES += $(call find_files,.d,,$C/$(SRC),$(TEST_FILTER_OUT))
 $O/fastunittests.d: $(filter-out %_slowtest.d,$(UNITTEST_FILES))
 $O/allunittests.d: $(UNITTEST_FILES)
 
-# 1. find any module named UnitTestRunner
-# 2. get the relative file path from `src` folder
-# 3. replace slashes with dots to get qualified module name
-TEST_RUNNER_MODULE?=$(shell \
-	  find ./ -path */src/*/core/UnitTestRunner.d \
-	| sed -n 's|^.\+/src/\(.\+/UnitTestRunner\).d$$|\1|p' \
-	| tr / .)
+# Test runner module. Uses ocean if available
+TEST_RUNNER_MODULE=$(shell \
+	for sub in ${SUBMODULES}; do \
+		if test "$$(basename $$sub)" = "ocean"; then \
+			echo ocean.core.UnitTestRunner; \
+			exit 0; \
+		fi \
+	done)
 
 # if no UnitTestRunner module is found and it was not overriden
 # from command line or Config.mak, use default D test runner

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,9 @@ Top-level Makefile
 To get started you need to have makd as a submodule (or copy it to your project)
 and create a top-level makefile for your project (or convert the old one).
 
-A typical Top-level ``Makefile`` should look like this::
+A typical Top-level ``Makefile`` should look like this:
+
+.. code:: make
 
         # Include the top-level makefile
         include submodules/makd/Makd.mak
@@ -43,7 +45,9 @@ it, which will be explained later.
 You can change this default target by explicitly overriding the
 ``.DEFAULT_GOAL`` variable, which tells GNU Make which target should be built
 when you just run ``make`` without arguments. If you set it, make sure you
-define it **after** including ``Makd.mak``, order is important in this case::
+define it **after** including ``Makd.mak``, order is important in this case:
+
+.. code:: make
 
         # Default goal for building this directory
         .DEFAULT_GOAL := some-target
@@ -60,7 +64,9 @@ Build.mak
 ---------
 This is the file where you define what your ``Makefile`` will actually do. Makd
 does a lot for you, so this file is usually very terse. To define a binary to
-compile, all you need to write in your ``Build.mak`` is this::
+compile, all you need to write in your ``Build.mak`` is this:
+
+.. code:: make
 
         $B/someapp: $C/src/main/someapp.d
 
@@ -75,7 +81,9 @@ different locations (to make this work you should refer to all the project
 files using this ``$C/`` *prefix* when you refer to the current directory of
 your ``Build.mak``).
 
-Usually you want a shortcut to type less, so you might want to add::
+Usually you want a shortcut to type less, so you might want to add:
+
+.. code:: make
 
         .PHONY: someapp
         someapp: $B/someapp
@@ -84,13 +92,17 @@ Now you can simply write ``make someapp`` to build it. Simple.
 
 But maybe you want to type just ``make``. Since the ``.DEFAULT_GOAL`` defined in
 your ``Makefile`` is ``all``, you can use the special ``all`` variable to add
-targets to build when is called::
+targets to build when is called:
+
+.. code:: make
 
         all += someapp
 
 Now you can simply write ``make`` and you'll get your program built.
 
-Putting it all together, your file should look like::
+Putting it all together, your file should look like:
+
+.. code:: make
 
         .PHONY: someapp
         someapp: $B/someapp
@@ -284,7 +296,9 @@ the special variable ``DVER``. For example::
         make DVER=2 test
 
 Inside your ``Build.mak`` you can also use this to build your project
-differently in D1 and D2, for example::
+differently in D1 and D2, for example:
+
+.. code:: make
 
         ifeq ($(DVER),2)
         rule: d2_file.d
@@ -388,7 +402,9 @@ exec
 Probably the most important is ``exec``. This function takes care of the pretty
 output and verboseness. Each time you write a custom rule (hopefully you won't
 need to do this often), you should probably use it. Here is the function
-*signature*::
+*signature*:
+
+.. code:: make
 
         $(call exec,command[,pretty_target[,pretty_command]])
 
@@ -397,7 +413,9 @@ be printed as the target that's being build (by default is ``$@``, i.e. the
 actual target being built), and ``pretty_command`` is the string that will be
 print as the command (by default the first word in ``command``).
 
-Here is an example rule::
+Here is an example rule:
+
+.. code:: make
 
         touch-file:
                 $(call exec,touch -m $@)
@@ -433,14 +451,18 @@ installed. The *signature* is::
 ``compare_op`` is the comparison operator it should be used by the check (by
 default is >=, but it can be any of <,<=,=,>=,>).
 
-You can use this as the first command to run for a target action, for example::
+You can use this as the first command to run for a target action, for example:
+
+.. code:: make
 
         myprogram: some-source.d
         	$(call check_deb,dstep,0.0.1)
         	rdmd --build --whatever.
 
 If you need to share it for multiple targets you can just make a simple alias
-with a lazy variable::
+with a lazy variable:
+
+.. code:: make
 
         check_dstep = $(call check_deb,dstep,0.0.1)
 
@@ -455,7 +477,9 @@ closer to a function than a variable. When we are in verbose mode, ``V`` is
 empty and when we are not in verbose mode is set to ``@``. The effect is you
 only get some Make output if we are not in verbose mode.
 
-For example, this::
+For example, this:
+
+.. code:: make
 
         test:
                 $Vecho test
@@ -487,7 +511,9 @@ doesn't get destroyed by a ``make clean``.
 
 To change variables based on the flavor (or define new flavors), usually the
 `Config.mak`_ is the place, and you can use normal Make constructs, for
-example::
+example:
+
+.. code:: make
 
         ifeq ($F,devel)
         override DFLAGS += -debug=ProjectDebug
@@ -506,7 +532,9 @@ to make, for example::
         make F=production
 
 If you need to define more flavors, you can do so by defining the
-``$(VALID_FLAVORS)`` variable in your ``Config.mak``, for example::
+``$(VALID_FLAVORS)`` variable in your ``Config.mak``, for example:
+
+.. code:: make
 
         VALID_FLAVORS := devel production profiling
 
@@ -518,7 +546,9 @@ variables for a particular target, and usually that's the best way to pass
 specific variables to a particular target.
 
 For example, you need to link one binary to a particular library but not the
-others, then just do::
+others, then just do:
+
+.. code:: make
 
         $B/prog-with-lib: override LDFLAGS += -lthelib
         $B/prog-with-lib: $C/src/progwithlibs.d
@@ -531,7 +561,9 @@ variable override is propagated, so if your target needs to build a prerequisite
 first, the building of the prerequisite will also see the modified variable. If
 you want to avoid this, Makd also expands the special variable
 ``$($@.EXTRA_FLAGS)``. That is ``$(<name of the target>.EXTRA_FLAGS)`` (yes,
-Make support recursive expansion of variables :D), for example::
+Make support recursive expansion of variables :D), for example:
+
+.. code:: make
 
         $B/prog-with-lib.EXTRA_FLAGS := -lthelib
         $B/prog: $C/src/prog.d
@@ -729,7 +761,9 @@ For convenience, here is a simple example:
 Suppose that the targets ``daemon`` and ``util`` build the binaries ``daemon``
 and ``util`` respectively, then you probably want to make sure you build those
 before making the package, so in the ``Build.mak`` file you should put
-something like::
+something like:
+
+.. code:: make
 
         $O/pkg-daemon.stamp: daemon
 
@@ -753,7 +787,9 @@ All the tests are built using these extra options::
 
 If you have a test script, you can easily add the target to run that script to
 ``$(test)`` too (or ``$(fasttest))`` and ``$(test)`` if it's really fast).
-For example::
+For example:
+
+.. code:: make
 
         .PHONY: supertest
         supertest:
@@ -819,14 +855,18 @@ use ``+=``, there might be other predefined modules to skip.
 
 For `Unit tests`_, you just have to add the individual files you want to exclude
 from the tests. You can use a single ``%`` as a wildcard to exclude a whole
-package for example::
+package for example:
+
+.. code:: make
 
         TEST_FILTER_OUT += \
                 $C/src/brokenmodule.d \
                 $C/src/brokenpackage/%
 
 For `Integration tests`_, you can only skip a full test program, to do that just
-exclude the ``main.d`` for that program. For example::
+exclude the ``main.d`` for that program. For example:
+
+.. code:: make
 
         TEST_FILTER_OUT += $C/test/brokenprog/main.d
 
@@ -837,13 +877,17 @@ Some tests might need special flags for the unittest to compile, like when you
 need to link to external libraries.
 
 For `Unit tests`_ you can add unittest specific flags by using the following
-syntax::
+syntax:
+
+.. code:: make
 
         $O/%unittests: override LDFLAGS += -lglib-2.0
 
 This will link all the unittests to the glib-2.0 library, both ``fastunittest``
 and ``allunittest``. To apply flags to an individual test use a more specific
-target, for example::
+target, for example:
+
+.. code:: make
 
         $O/allunittests: override LDFLAGS += -lextra
 
@@ -865,7 +909,9 @@ used, the ``-k`` option will be passed to the unit test runner too, and if
 runner.
 
 For `Integration tests`_ the way to pass special flags is similar, but not the
-same. Use the following syntax::
+same. Use the following syntax:
+
+.. code:: make
 
         $O/test-feature: override LDFLAGS += -lglib-2.0
 
@@ -878,7 +924,9 @@ To pass flags to the test program execution, you can use the special variable
 test, the only way to do this for individual suites is to write it in the makefile,
 otherwise the same flags will be used to run **all** the integration tests.
 To run the *feature* integration test with the flag ``--verbose``, for example,
-you can do this (pay attention to the ``.stamp`` suffix, it is necessary)::
+you can do this (pay attention to the ``.stamp`` suffix, it is necessary):
+
+.. code:: make
 
         $O/test-feature.stamp: override ITFLAGS += --verbose
 

--- a/README.rst
+++ b/README.rst
@@ -304,6 +304,11 @@ differently in D1 and D2, for example:
         rule: d2_file.d
         endif
 
+To make project always use D2 compiler, simply define this variable in
+``Config.mak``:
+
+        DVER:=2
+
 Variables you might want to override
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * The special target variables ``all``, ``test``, ``doc``.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,7 +9,3 @@ Bug Fixes
 
 New Features
 ============
-
-* Add some experimental basic packaging support. Please refer to the
-  [documentation](README.rst#packaging) for details.
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,3 +9,9 @@ Bug Fixes
 
 New Features
 ============
+
+* ``Makd.mak``
+
+  If ``UnitTestRunner.d`` module is neither found not explicitly
+  configured by developer, makd will resort to using default D test
+  runner instead.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,8 @@ New Features
   If ``UnitTestRunner.d`` module is neither found not explicitly
   configured by developer, makd will resort to using default D test
   runner instead.
+
+* ``Makd.mak``
+
+  Now `DVER` variable is set only if it was not already defined,
+  allow to put it into `Config.makd` for D2-only projects.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,22 +1,12 @@
 Dependencies
 ============
 
-Migration Instructions
-======================
-
-Bug Fixes
-=========
-
 New Features
 ============
 
-* ``Makd.mak``
-
-  If ``UnitTestRunner.d`` module is neither found not explicitly
+* If `UnitTestRunner.d` module is neither found not explicitly
   configured by developer, makd will resort to using default D test
   runner instead.
 
-* ``Makd.mak``
-
-  Now `DVER` variable is set only if it was not already defined,
+* Now `DVER` variable is set only if it was not already defined,
   allow to put it into `Config.makd` for D2-only projects.


### PR DESCRIPTION
Extends the logic for the `make test` target to use the most appropriate `UnitTestRunner.d` module. 
Will use the most shallow path, e.g. if you have (number at the tail is the path deepness)

```
./submodules/ocean/src/ocean/core/UnitTestRunner.d 6
./submodules/lib1/submodules/ocean/src/ocean/core/UnitTestRunner.d 8
./submodules/lib2/submodules/ocean/src/ocean/core/UnitTestRunner.d 8
./submodules/lib3/submodules/ocean/src/tango/core/UnitTestRunner.d 8
```

it will take the first one in that list.
