### PR TITLE
Don't cache mkpkg .pyc files

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -423,7 +423,8 @@ pkg: $(patsubst $(PKG)/%.pkg,$O/pkg-%.stamp,$(wildcard $(PKG)/*.pkg))
 # is a different file)
 $O/pkg-%.stamp: $(PKG)/%.pkg
 	$(PKG_PREBUILD)
-	$(call exec,$(MAKD_PATH)/mkpkg $(if $V,,-vv) -D-p"$P" -F "$(FPM)" \
+	$(call exec,PYTHONDONTWRITEBYTECODE=1 $(MAKD_PATH)/mkpkg \
+		$(if $V,,-vv) -D-p"$P" -F "$(FPM)" \
 		$(PKG_DEFAULTS) \
 		-d suffix="$(PKG_SUFFIX)" -d version="$(PKGVERSION)" \
 		-d builddir="$G" -d bindir="$B" -d name="$*$(PKG_SUFFIX)" \


### PR DESCRIPTION
Python will create a directory `__pycache__` in the pkg/ directory by default caching the user scripts, but these scripts are so trivial that is not worth polluting the user's workspace.
