### PR TITLE
mkpkg: Make `FUN.autodeps()` accept multiple args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -643,11 +643,12 @@ passed to the ``mkpkg`` util. By default Makd pass the following variables:
 ``mkpkg`` also defines the following built-in functions in the special built-in
 variable ``FUN``:
 
-``autodeps(bin)``
+``autodeps(bin[, ...])``
         returns a sorted ``list()`` of packages ``bin`` depends on based on the
         outcome of running the ``ldd`` utility and searching to which packages
-        the libraries is linked belong to using ``dpkg``. This function is
-        tighly coupled to Debian packages for now.
+        the libraries is linked belong to using ``dpkg``. You can specify
+        multiple binaries to get a list of dependencies for all of them. This
+        function is tighly coupled to Debian packages for now.
 
 Generated packages will be stored in the ``$P`` directory (by default
 ``$G/pkg``. Since each package usually have a different name, as the version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,5 @@
 New Features
 ============
+
+* `mkpkg`: `FUN.autodeps()` now accepts multiple arguments. The set of
+  dependencies for all of them are returned.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,2 @@
 New Features
 ============
-
-* Don't search for any `UnitTestRunner.d` file, just use the `UnitTestRunner`
-  Ocean's module if Ocean is configured as a submodule.
-
-* `doc` target will now generate documentation using
-  [harbored-mod](https://github.com/kiith-sa/harbored-mod)
-  tool by default.
-
-* Make `TEST_RUNNER_STRING` overrideable. In case you need to plug-in a custom
-  test runner, now you can also override this variable to make it even more
-  flexible.

--- a/mkpkg
+++ b/mkpkg
@@ -118,10 +118,11 @@ class Functions:
         debugf("Output: {}", output)
         return regex.findall(output)
 
-    def autodeps(self, fname):
+    def autodeps(self, *fnames):
         # XXX: Only debian packages supported for now
+        from itertools import chain
         deps = set()
-        for lib, path in self._parse_cmd('ldd', fname):
+        for lib, path in chain(*[self._parse_cmd('ldd', f) for f in fnames]):
             if lib in self.autodeps_exclusions:
                 debugf("`{}` is in autodeps_exclusions, skipping...", lib)
                 continue


### PR DESCRIPTION
It's a common pattern to have packages providing multiple binaries, in which case the package should have all the requirements for all the binaries as dependencies. This simplifies the use of `autodeps` for these packages, as one can just use `depends = FUN.autodeps(*binaries)`.
