### PR TITLE
Add dependency graph generation for cycles

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -550,7 +550,7 @@ $O/test-%.stamp: $O/test-%
 	$Vtouch $@
 
 # Documentation rules
-###################
+######################
 
 # General rule to run the harbored-mod generator
 $O/doc.stamp: $(shell find $(SRC) -type f \( -name '*.d' -o -name '*.di' \))

--- a/Makd.mak
+++ b/Makd.mak
@@ -125,6 +125,12 @@ HMODFLAGS ?= --project-name $(PROJECT_NAME) --project-version $(VERSION)
 # Default fpm binary location
 FPM ?= fpm
 
+# Default dot binary location
+DOT ?= dot
+
+# Default flags to pass to graph-deps (see --help for details)
+GRAPH_DEPS_FLAGS ?= -c -C
+
 # Default fpm flags. By default it builds Debian packages from files, a Debian
 # changelog is provided, and a version and iteration (using the Debian version)
 # (defined lazily so we can use target variables)
@@ -558,6 +564,21 @@ $O/doc.stamp: $(shell find $(SRC) -type f \( -name '*.d' -o -name '*.di' \))
 	$Vtouch $@
 
 doc += $O/doc.stamp
+
+# Graph dependencies rule
+##########################
+
+.PHONY: graph-deps
+graph-deps: $O/deps.svg
+
+$O/%.svg: $O/%.dot
+	$(call exec,$(DOT) -T svg $< -o $@)
+
+$O/deps.dot: $O/depsfile
+	$(call exec,$(MAKD_PATH)/graph-deps $(GRAPH_DEPS_FLAGS) $< $@,$@,graph-deps)
+
+$O/depsfile: $O/allunittests.d
+	$(call exec,$(DC) $(DFLAGS) -o- -deps=$@ $<)
 
 # Create build directory structure
 ###################################

--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,7 @@ work ;). If you can't do that (because you generated a source file for example),
 you can use the special variable ``clean`` too (``clean += src/trash.d
 src/garbage.d`` for example).
 
-The ``doc`` itarget will, by default, call `harbored-mod
+The ``doc`` target will, by default, call `harbored-mod
 <https://github.com/kiith-sa/harbored-mod>`_ tool to generate the documentation
 for the project from DDOC comments inside source files.  Harbored-mod is
 choosen because it also allows Markdown syntax which makes the documentation

--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,7 @@ whole set of predefined targets are:
 * ``integrationtest``
 * ``doc``
 * ``pkg``
+* ``graph-deps``
 
 Not all of them will be useful out of the box, you need to assign other targets
 to them to be useful. In this category are: ``all`` and ``doc``. For ``all`` we
@@ -278,6 +279,14 @@ for the project from DDOC comments inside source files.  Harbored-mod is
 choosen because it also allows Markdown syntax which makes the documentation
 easier to read in the source files, as it doesn't require as much DDOC macros
 as the dmd.
+
+The ``graph-deps`` target is used to generate a dependencies graph. To generate
+this graph the ``dot`` tool from the `graphviz <http://www.graphviz.org/>`_
+visualization software is used (the location of the tool can be specified via
+the ``DOT`` variable). By default only cyclic dependencies are generated in the
+graph, but other kind of dependencies graphs can be generated (please take
+a look at the ``./graph-deps --help`` ouput for details, you can override the
+options to pass to ``graph-deps`` using the ``GRAPH_DEPS_FLAGS`` variables).
 
 Predefined variables
 --------------------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,8 @@ New Features
 
 * `mkpkg`: `FUN.autodeps()` now accepts multiple arguments. The set of
   dependencies for all of them are returned.
+
+* A new `graph-deps` target generates a dependencies graph (by default only with
+  cyclic dependencies). To generate the graph the ``dot`` tool from the
+  `graphviz <http://www.graphviz.org/>`_ visualization software is used.
+

--- a/graph-deps
+++ b/graph-deps
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-# This script takes a dmd dependency file, and outputs a graph in graphviz
-# format also, detect cycles
+# This script takes a dmd dependency file, optionally detect cycles, and
+# outputs a graph in graphviz format.
 #
 # Based on: https://github.com/dellort/lumbricus/blob/d2/src/scripts/deps.py
 # Which used code from: http://www.logarithmic.net/pfh/blog/01208083168
@@ -40,13 +40,13 @@ parser.add_option("-h", "--help",
     help="show this help message and exit")
 parser.add_option("-c", "--cycles-only",
     action="store_true", dest="cycles_only", default=False,
-    help="show only nodes, that are parts of a cycle")
+    help="show only nodes that are parts of a cycle")
 parser.add_option("-C", "--cycle-edges-only",
     action="store_true", dest="cycle_edges_only", default=False,
-    help="show only edges, that are part of a cycle")
+    help="show only edges that are part of a cycle")
 parser.add_option("-e", "--exclude",
     action="append", dest="ignore", default=[],
-    help="ignore module (or if it ends with a '.', ignore all packages starting with this)")
+    help="ignore a module or an entire package (if it ends with a '.')")
 parser.add_option("-i", "--include",
     action="append", dest="include", default=[],
     help="include only this module/package (similar to --exclude)")
@@ -61,7 +61,7 @@ parser.add_option("--imports",
     help="include only modules which import this module (transitively)")
 parser.add_option("--imports-depth",
     action="store", type="int", dest="import_depth", default=0,
-    help="how many indirections max for --imports (0 means no restriction)")
+    help="maximum number of indirections for --imports (0 means no limit)")
 
 # options contains all "dest" arg names as normal members
 # args are all left non-option arguments as sequence

--- a/graph-deps
+++ b/graph-deps
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+#
+# This script takes a dmd dependency file, and outputs a graph in graphviz
+# format also, detect cycles
+#
+# Based on: https://github.com/dellort/lumbricus/blob/d2/src/scripts/deps.py
+# Which used code from: http://www.logarithmic.net/pfh/blog/01208083168
+# (see https://github.com/sociomantic-tsunami/makd/pull/19 for details on
+# license changes)
+#
+# Copyright 2009-2016 Vincent Lang.
+# Copyright 2016 Sociomantic Labs GmbH.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+from optparse import OptionParser
+import sys
+import re
+
+std_ignore = ["object", "tango.", "std.", "core."]
+
+def print_help(option, opt, value, parser, do_exit=True):
+    parser.print_help()
+    print ""
+    print "Generate the dependency file with:"
+    print "    dmd -o- -deps=depfile rootfile.d"
+    print ""
+    print "Example to generate a graph with circular dependencies only:"
+    print "    %s -c -C depfile graph.out" % parser.get_prog_name()
+    print ""
+    print "Render graph.out with:"
+    print "    dot -T svg graph.out -o graph.svg"
+    if do_exit: sys.exit(1)
+
+parser = OptionParser(usage="%prog [options] depfile graph.out",
+    description="Create a graphviz dependency graph from dmd module dependency file.",
+    add_help_option=False)
+parser.add_option("-h", "--help",
+    action="callback", callback=print_help,
+    help="show this help message and exit")
+parser.add_option("-c", "--cycles-only",
+    action="store_true", dest="cycles_only", default=False,
+    help="show only nodes, that are parts of a cycle")
+parser.add_option("-C", "--cycle-edges-only",
+    action="store_true", dest="cycle_edges_only", default=False,
+    help="show only edges, that are part of a cycle")
+parser.add_option("-e", "--exclude",
+    action="append", dest="ignore", default=[],
+    help="ignore module (or if it ends with a '.', ignore all packages starting with this)")
+parser.add_option("-i", "--include",
+    action="append", dest="include", default=[],
+    help="include only this module/package (similar to --exclude)")
+parser.add_option("-p", "--package-mode",
+    action="store_true", dest="package_mode", default=False,
+    help="show dependencies between packages")
+parser.add_option("--no-std-ignore",
+    action="store_true", dest="no_std_ignore", default=False,
+    help=("don't ignore standard modules (%s)" % std_ignore))
+parser.add_option("--imports",
+    action="append", dest="imports", default=[],
+    help="include only modules which import this module (transitively)")
+parser.add_option("--imports-depth",
+    action="store", type="int", dest="import_depth", default=0,
+    help="how many indirections max for --imports (0 means no restriction)")
+
+# options contains all "dest" arg names as normal members
+# args are all left non-option arguments as sequence
+(options, args) = parser.parse_args()
+
+if not options.no_std_ignore:
+    options.ignore.extend(std_ignore)
+
+if len(args) != 2:
+    print_help(None, None, None, parser, False)
+    print ""
+    print "2 arguments expected (depfile, outfile), but received %s." % args
+    sys.exit(1)
+
+# nodes[Node.name] = Node
+nodes = {}
+
+# one node per module (or package in package mode)
+class Node:
+    def __init__(self, name, id):
+        self.name = name
+        self.id = id
+        # modules this module imports
+        self.adj = []
+        # number of cluster with cyclic dependencies
+        # first cycle is 0, -1 means not part of a cycle
+        self.cycle = -1
+
+def compare_module_name(name, pattern):
+    if name == pattern: return True
+    if pattern.endswith(".") and name.startswith(pattern): return True
+    return False
+
+def is_ignored(name):
+    for i in options.ignore:
+        if compare_module_name(name, i): return True
+    if len(options.include) > 0:
+        for i in options.include:
+            if not compare_module_name(name, i): return True
+    return False
+
+def getnode(name):
+    if not nodes.has_key(name):
+        nodes[name] = Node(name, len(nodes))
+    return nodes[name]
+
+# foo.moo.mod => foo.moo
+# top-level files are considered to be in package "root"
+def mod_to_package(mod):
+    idx = mod.rfind(".")
+    if idx < 0: idx = 0
+    pkg = mod[:idx]
+    if pkg == "": pkg = "root"
+    return pkg
+
+# append, but only if it isn't already in the array
+def append_unique(seq, item):
+    if item in seq: return
+    seq.append(item)
+
+deps = open(args[0])
+# ignores some parts of the information
+p = re.compile("([A-Za-z0-9._]+) \(.*\) : .* : ([A-Za-z0-9._]+) \(.*")
+for line in deps:
+    mod, imp = p.match(line).groups()
+    if is_ignored(mod) or is_ignored(imp): continue
+    if options.package_mode:
+        mod = mod_to_package(mod)
+        imp = mod_to_package(imp)
+        if mod == imp:
+            continue
+    append_unique(getnode(mod).adj, getnode(imp))
+
+# optional feature for looking at specific modules
+if options.imports:
+    marked = {}
+    for i in options.imports:
+        marked[getnode(i)] = True
+    # this is like a reverse GC xD
+    # mark all nodes which refer to at least one marked node
+    depth = options.import_depth
+    n = 0
+    while depth == 0 or n < depth:
+        n += 1
+        nmark = {}
+        for x in nodes.itervalues():
+            if x not in marked:
+                for a in x.adj:
+                    if a in marked:
+                        nmark[x] = True
+        if len(nmark) == 0:
+            break
+        for x in nmark.iterkeys():
+            marked[x] = True
+    # remove all unmarked nodes
+    nodes = {}
+    for x in marked.iterkeys():
+        nodes[x.name] = x
+        x.adj = [i for i in x.adj if (i in marked)]
+
+# tarjan algorithm to find cycles
+# code borrowed from http://www.logarithmic.net/pfh/blog/01208083168
+result = []
+stack = []
+low = {}
+
+def visit(node):
+    if node in low: return
+
+    num = len(low)
+    low[node] = num
+    stack_pos = len(stack)
+    stack.append(node)
+
+    for successor in node.adj:
+        visit(successor)
+        low[node] = min(low[node], low[successor])
+
+    if num == low[node]:
+        component = tuple(stack[stack_pos:])
+        del stack[stack_pos:]
+        result.append(component)
+        for item in component:
+            low[item] = len(nodes)
+
+for node in nodes.values():
+    visit(node)
+# end tarjan
+
+cycles = 0
+for e in result:
+    if len(e) > 1:
+        #s = ""
+        for x in e:
+            #s += x.name + " "
+            x.cycle = cycles
+        #print "> %s <" % s
+        cycles = cycles + 1
+
+# output graphviz graph
+
+outf = open(args[1], "w")
+
+outf.write('digraph "a" {\n')
+
+for node in nodes.values():
+    if options.cycles_only and not node.cycle >= 0: continue
+    label = node.name
+    if node.cycle >= 0:
+        label = "%s [%s]" % (label, node.cycle)
+    outf.write('  %s [label="%s"];\n' % (node.id, label))
+    for to in node.adj:
+        if options.cycles_only and not to.cycle >= 0: continue
+        same_cycle = node.cycle >= 0 and node.cycle == to.cycle
+        if options.cycle_edges_only and not same_cycle: continue
+        outf.write('  %s -> %s [weight=%s %s]\n' % (node.id,
+            to.id, 1 if same_cycle else 0, 'color=red' if same_cycle else ''))
+
+outf.write('}\n')


### PR DESCRIPTION
A new target `graph-deps` will generate a graph in `$O/deps.svg` showing all circular dependencies for the project. Using different options other kind of dependency graphs can be generated.

**Documentation is still missing but you can already try this**.
