### PR TITLE
Fix wrong if branches of d1to2fix feature check

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -652,9 +652,9 @@ d2conv: $O/d2conv.stamp
 $O/d2conv.stamp: $C
 	$Vfind $C -type f -regex '^.+\.d$$' > $@
 ifeq "$(shell d1to2fix --help | grep -- --input)" ""
-	$(call exec, d1to2fix $(DIMPORTPATHS) --fatal --input=$@)
-else
 	$(call exec, d1to2fix --fatal `cat $@`)
+else
+	$(call exec, d1to2fix $(DIMPORTPATHS) --fatal --input=$@)
 endif
 
 # Automatic dependency handling

--- a/Makd.mak
+++ b/Makd.mak
@@ -651,7 +651,7 @@ d2conv: $O/d2conv.stamp
 
 $O/d2conv.stamp: $C
 	$Vfind $C -type f -regex '^.+\.d$$' > $@
-ifeq "$(shell d1to2fix --help | grep -- --input)" ""
+ifeq "$(shell d1to2fix --help 2>/dev/null | grep -- --input)" ""
 	$(call exec, d1to2fix --fatal `cat $@`)
 else
 	$(call exec, d1to2fix $(DIMPORTPATHS) --fatal --input=$@)


### PR DESCRIPTION
Actions upon each branch were exchanged to what they must have
been. Resulted in misbehaving D2 conversion not using new d1to2fix features.