### PR TITLE
`make pkg` cannot handle UTF8 in commit messages

### DIFF
--- a/git-deblog
+++ b/git-deblog
@@ -169,7 +169,7 @@ def parse_args():
             "commit is used if present)")
     parser.add_argument('-d', '--dist-name', default=get_dist(),
             help="specifies the distribution name (by default obtained from "
-            "lsb_release")
+            "lsb_release)")
     parser.add_argument('-u', '--urgency', default='medium',
             choices='low medium high emergency critical'.split(),
             help="specifies the distribution name (by default obtained from "

--- a/git-deblog
+++ b/git-deblog
@@ -5,18 +5,28 @@
 # (See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 import sys
-import locale
 from datetime import datetime
 from subprocess import CalledProcessError, PIPE
-
-
-ENC = locale.getpreferredencoding()
 
 
 def main():
     parser, args = parse_args()
 
-    git_log = get_log(args.git_log_args)
+    # Git assumes UTF-8 for commit messages, unless there is a config option
+    # overriding it. Even if the config option is not used, Git just emits
+    # warnings, so users could use any encoding, so we allow overriding this
+    # via command-line options.
+    # See: https://git-scm.com/docs/git-commit#_discussion
+    commit_encoding = None
+    try:
+        commit_encoding = run('git config i18n.commitencoding'.split())
+    except CalledProcessError as e:
+        if e.returncode != 1: # Config not defined
+            raise e
+    if not commit_encoding:
+        commit_encoding = 'UTF-8'
+
+    git_log = get_log(commit_encoding, args.git_log_args)
     if not git_log:
         return
 
@@ -49,8 +59,11 @@ def main():
 
 
 def run(*args, **kwargs):
+    from locale import getpreferredencoding
     from subprocess import check_output
-    return check_output(*args, **kwargs).strip().decode(ENC)
+    encoding = getpreferredencoding()
+    dbg('running command: {} (using {} encoding)', args[0], encoding)
+    return check_output(*args, **kwargs).strip().decode(encoding)
 
 
 def get_dist():
@@ -94,17 +107,17 @@ class Commit:
         return 'Commit({!r}, {!r})'.format(self.hash, self.message)
 
 
-def get_log(opts=()):
+def get_log(encoding, opts=()):
     from subprocess import Popen
 
     cmd = ('git', 'log') + tuple(opts) + ('--format=%h%x1f%D%x1f%s%x1e',)
-    dbg('running command: {}', cmd)
+    dbg('running command: {} (using {} encoding)', cmd, encoding)
     p = Popen(cmd, stdout=PIPE)
 
     log = []
     row = ''
     for l in p.stdout.readlines():
-        l = l.decode(ENC)
+        l = l.decode(encoding)
         # accumulate if the end of record is not found
         if not l.endswith('\x1e\n'):
             row += l
@@ -167,7 +180,7 @@ def parse_args():
     parser.add_argument('-i', '--initial-version',
             help="specifies an initial version (by default the tag of the last "
             "commit is used if present)")
-    parser.add_argument('-d', '--dist-name', default=get_dist(),
+    parser.add_argument('-d', '--dist-name',
             help="specifies the distribution name (by default obtained from "
             "lsb_release)")
     parser.add_argument('-u', '--urgency', default='medium',
@@ -180,6 +193,9 @@ def parse_args():
 
     global VERBOSE
     VERBOSE = args.verbose
+
+    if args.dist_name is None:
+        args.dist_name = get_dist()
 
     return parser, args
 

--- a/git-deblog
+++ b/git-deblog
@@ -172,8 +172,7 @@ def parse_args():
             "lsb_release)")
     parser.add_argument('-u', '--urgency', default='medium',
             choices='low medium high emergency critical'.split(),
-            help="specifies the distribution name (by default obtained from "
-            "lsb_release")
+            help="specifies the urgency of the update, in Debian terms")
     parser.add_argument('pkg_name', help="package name")
     parser.add_argument('git_log_args', nargs=REMAINDER,
             help="extra arguments to be passed to git log")


### PR DESCRIPTION
It seems that if commit messages include UTF8 characters, `make pgk` will fail with an error message along the lines of the following:
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 96: ordinal not in range(128)
```

This seems to come down to the following command in the `git-deblog` script:
https://github.com/sociomantic-tsunami/makd/blob/1446612df547465d402d349744e8cab0f1358dbf/git-deblog#L125