### PR TITLE
git-deblog: Fix header when no tag in HEAD

### DIFF
--- a/git-deblog
+++ b/git-deblog
@@ -16,19 +16,25 @@ ENC = locale.getpreferredencoding()
 def main():
     parser, args = parse_args()
 
-    for i, obj in enumerate(get_log(args.git_log_args)):
-        if i == 0:
-            if isinstance(obj, Commit):
-                tag = Tag(obj.hash, args.initial_version, get_git_author(),
-                        datetime.now())
-            else:
-                tag = obj
-            if args.initial_version:
-                tag.name = args.initial_version
-            if tag.name is None:
-                parser.error('{}: no tag for the last commit, you must '
-                        'specify an initial version (--initial-version)')
+    git_log = get_log(args.git_log_args)
+    if not git_log:
+        return
 
+    first = git_log[0]
+    if isinstance(first, Commit):
+        tag = Tag(first.hash, args.initial_version, get_git_author(),
+                datetime.now())
+    else:
+        tag = first
+    if args.initial_version:
+        tag.name = args.initial_version
+    if tag.name is None:
+        parser.error('{}: no tag for the last commit, you must '
+                'specify an initial version (--initial-version)')
+    if tag is not first:
+        git_log.insert(0, tag)
+
+    for i, obj in enumerate(git_log):
         if isinstance(obj, Tag):
             if i > 0:
                 print()

--- a/git-deblog
+++ b/git-deblog
@@ -73,6 +73,9 @@ class Tag:
         self.date = date
     def __str__(self):
         return self.name
+    def __repr__(self):
+        return 'Tag({!r}, {!r}, {!r}, {!r})'.format(
+                self.hash, self.name, self.author, self.date)
 
 
 class Commit:
@@ -81,6 +84,8 @@ class Commit:
         self.message = message
     def __str__(self):
         return self.message
+    def __repr__(self):
+        return 'Commit({!r}, {!r})'.format(self.hash, self.message)
 
 
 def get_log(opts=()):


### PR DESCRIPTION
When the current HEAD is not at a tag, no changelog header is printed.
This commit fixes this issue.