### PR TITLE
git-deblog: Warn about wrong decoding

### DIFF
--- a/git-deblog
+++ b/git-deblog
@@ -19,7 +19,7 @@ def main():
     # See: https://git-scm.com/docs/git-commit#_discussion
     commit_encoding = None
     try:
-        commit_encoding = run('git config i18n.commitencoding'.split())
+        commit_encoding = run('git config i18n.logOutputEncoding'.split())
     except CalledProcessError as e:
         if e.returncode != 1: # Config not defined
             raise e

--- a/git-deblog
+++ b/git-deblog
@@ -10,6 +10,8 @@ from subprocess import CalledProcessError, PIPE
 
 
 def main():
+    setup_decoder()
+
     parser, args = parse_args()
 
     # Git assumes UTF-8 for commit messages, unless there is a config option
@@ -63,7 +65,12 @@ def run(*args, **kwargs):
     from subprocess import check_output
     encoding = getpreferredencoding()
     dbg('running command: {} (using {} encoding)', args[0], encoding)
-    return check_output(*args, **kwargs).strip().decode(encoding)
+    output = check_output(*args, **kwargs).strip()
+    (output, errors) = decode_count(output, encoding)
+    if errors:
+        warn('found {} errors when trying to decode the output of "{}" '
+                '(using encoding {})', errors, ' '.join(args[0]), encoding)
+    return output
 
 
 def get_dist():
@@ -116,8 +123,10 @@ def get_log(encoding, opts=()):
 
     log = []
     row = ''
+    # Reset decoding errors
+    decoding_error_count = 0
     for l in p.stdout.readlines():
-        l = l.decode(encoding)
+        l = l.decode(encoding, errors="replacecount")
         # accumulate if the end of record is not found
         if not l.endswith('\x1e\n'):
             row += l
@@ -133,6 +142,10 @@ def get_log(encoding, opts=()):
 
     status = p.wait()
     assert status == 0
+
+    if decoding_error_count:
+        warn('found {} errors when trying to decode the output of "git log" '
+                '(using encoding {})', errors, encoding)
 
     return log
 
@@ -198,6 +211,31 @@ def parse_args():
         args.dist_name = get_dist()
 
     return parser, args
+
+
+decoding_error_count = 0
+def setup_decoder():
+    # Extend backslashreplace_errors to handle decode errors too.
+    # Borrowed from:https://gist.github.com/ynkdir/867347
+    # But also store if we had problems decoding
+    import codecs
+    _backslashreplace_errors = codecs.backslashreplace_errors
+    def replacecount_errors(exc):
+        if isinstance(exc, UnicodeDecodeError):
+            global decoding_error_count
+            decoding_error_count += 1
+            tohex = lambda c: "\\x{0:02x}".format(c)
+            u = "".join(tohex(c) for c in exc.object[exc.start:exc.end])
+            return (u, exc.end)
+        return _backslashreplace_errors(exc)
+
+    codecs.register_error("replacecount", replacecount_errors)
+
+
+def decode_count(s, encoding):
+    prev_count = decoding_error_count
+    return (s.decode(encoding, errors="replacecount"),
+            decoding_error_count - prev_count)
 
 
 def dbg(fmt, *args, **kwargs):

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -8,9 +8,6 @@
 rev_file=src/Version.d
 author="`git config user.name`"
 
-# Get compiler version
-compiler="`${DC:-dmd} | head -1`"
-
 # Get the current date (might be overridden by command-line options later)
 date=$(date -u +"%Y-%m-%d %H:%M:%S %Z")
 
@@ -72,6 +69,9 @@ then
     echo $version
     exit 0
 fi
+
+# Get compiler version
+compiler="`${DC:-dmd} | head -1`"
 
 template="$1"; shift
 

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -22,7 +22,7 @@ Options:
 
 -o FILE      Where to write the output (Version.d) file (default: $rev_file)
 -a AUTHOR    Author of the build (default: detected, currently $author)
--d DATE      Build date string (default: output of '$date_cmd')
+-d DATE      Build date string (default now: $date)
 -m MODULE    Module name to use in the module declaration (default: built from -o)
 -v           Be more verbose (print a message if the file was updated)
 -p           Only print this repository version and exit


### PR DESCRIPTION
Instead of vomiting a backtrace to the user if decoding errors are
found, print a nice(r) warning saying X error were found while trying to
decode the output of a particular command, using a particular encoding.

The program will also continue working normally and the broken
characters will be output using a simple backslash replacement string.

This is an improvement over #30 and related to #33.