### PR TITLE
Merge tag 'v1.7.3' into v1.x.x

### DIFF
--- a/git-deblog
+++ b/git-deblog
@@ -19,7 +19,7 @@ def main():
     # See: https://git-scm.com/docs/git-commit#_discussion
     commit_encoding = None
     try:
-        commit_encoding = run('git config i18n.commitencoding'.split())
+        commit_encoding = run('git config i18n.logOutputEncoding'.split())
     except CalledProcessError as e:
         if e.returncode != 1: # Config not defined
             raise e

--- a/git-deblog
+++ b/git-deblog
@@ -169,7 +169,7 @@ def parse_args():
             "commit is used if present)")
     parser.add_argument('-d', '--dist-name', default=get_dist(),
             help="specifies the distribution name (by default obtained from "
-            "lsb_release")
+            "lsb_release)")
     parser.add_argument('-u', '--urgency', default='medium',
             choices='low medium high emergency critical'.split(),
             help="specifies the distribution name (by default obtained from "

--- a/git-deblog
+++ b/git-deblog
@@ -16,19 +16,25 @@ ENC = locale.getpreferredencoding()
 def main():
     parser, args = parse_args()
 
-    for i, obj in enumerate(get_log(args.git_log_args)):
-        if i == 0:
-            if isinstance(obj, Commit):
-                tag = Tag(obj.hash, args.initial_version, get_git_author(),
-                        datetime.now())
-            else:
-                tag = obj
-            if args.initial_version:
-                tag.name = args.initial_version
-            if tag.name is None:
-                parser.error('{}: no tag for the last commit, you must '
-                        'specify an initial version (--initial-version)')
+    git_log = get_log(args.git_log_args)
+    if not git_log:
+        return
 
+    first = git_log[0]
+    if isinstance(first, Commit):
+        tag = Tag(first.hash, args.initial_version, get_git_author(),
+                datetime.now())
+    else:
+        tag = first
+    if args.initial_version:
+        tag.name = args.initial_version
+    if tag.name is None:
+        parser.error('{}: no tag for the last commit, you must '
+                'specify an initial version (--initial-version)')
+    if tag is not first:
+        git_log.insert(0, tag)
+
+    for i, obj in enumerate(git_log):
         if isinstance(obj, Tag):
             if i > 0:
                 print()

--- a/git-deblog
+++ b/git-deblog
@@ -73,6 +73,9 @@ class Tag:
         self.date = date
     def __str__(self):
         return self.name
+    def __repr__(self):
+        return 'Tag({!r}, {!r}, {!r}, {!r})'.format(
+                self.hash, self.name, self.author, self.date)
 
 
 class Commit:
@@ -81,6 +84,8 @@ class Commit:
         self.message = message
     def __str__(self):
         return self.message
+    def __repr__(self):
+        return 'Commit({!r}, {!r})'.format(self.hash, self.message)
 
 
 def get_log(opts=()):

--- a/git-deblog
+++ b/git-deblog
@@ -10,6 +10,8 @@ from subprocess import CalledProcessError, PIPE
 
 
 def main():
+    setup_decoder()
+
     parser, args = parse_args()
 
     # Git assumes UTF-8 for commit messages, unless there is a config option
@@ -63,7 +65,12 @@ def run(*args, **kwargs):
     from subprocess import check_output
     encoding = getpreferredencoding()
     dbg('running command: {} (using {} encoding)', args[0], encoding)
-    return check_output(*args, **kwargs).strip().decode(encoding)
+    output = check_output(*args, **kwargs).strip()
+    (output, errors) = decode_count(output, encoding)
+    if errors:
+        warn('found {} errors when trying to decode the output of "{}" '
+                '(using encoding {})', errors, ' '.join(args[0]), encoding)
+    return output
 
 
 def get_dist():
@@ -116,8 +123,10 @@ def get_log(encoding, opts=()):
 
     log = []
     row = ''
+    # Reset decoding errors
+    decoding_error_count = 0
     for l in p.stdout.readlines():
-        l = l.decode(encoding)
+        l = l.decode(encoding, errors="replacecount")
         # accumulate if the end of record is not found
         if not l.endswith('\x1e\n'):
             row += l
@@ -133,6 +142,10 @@ def get_log(encoding, opts=()):
 
     status = p.wait()
     assert status == 0
+
+    if decoding_error_count:
+        warn('found {} errors when trying to decode the output of "git log" '
+                '(using encoding {})', errors, encoding)
 
     return log
 
@@ -198,6 +211,31 @@ def parse_args():
         args.dist_name = get_dist()
 
     return parser, args
+
+
+decoding_error_count = 0
+def setup_decoder():
+    # Extend backslashreplace_errors to handle decode errors too.
+    # Borrowed from:https://gist.github.com/ynkdir/867347
+    # But also store if we had problems decoding
+    import codecs
+    _backslashreplace_errors = codecs.backslashreplace_errors
+    def replacecount_errors(exc):
+        if isinstance(exc, UnicodeDecodeError):
+            global decoding_error_count
+            decoding_error_count += 1
+            tohex = lambda c: "\\x{0:02x}".format(c)
+            u = "".join(tohex(c) for c in exc.object[exc.start:exc.end])
+            return (u, exc.end)
+        return _backslashreplace_errors(exc)
+
+    codecs.register_error("replacecount", replacecount_errors)
+
+
+def decode_count(s, encoding):
+    prev_count = decoding_error_count
+    return (s.decode(encoding, errors="replacecount"),
+            decoding_error_count - prev_count)
 
 
 def dbg(fmt, *args, **kwargs):

--- a/git-deblog
+++ b/git-deblog
@@ -5,18 +5,28 @@
 # (See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 import sys
-import locale
 from datetime import datetime
 from subprocess import CalledProcessError, PIPE
-
-
-ENC = locale.getpreferredencoding()
 
 
 def main():
     parser, args = parse_args()
 
-    git_log = get_log(args.git_log_args)
+    # Git assumes UTF-8 for commit messages, unless there is a config option
+    # overriding it. Even if the config option is not used, Git just emits
+    # warnings, so users could use any encoding, so we allow overriding this
+    # via command-line options.
+    # See: https://git-scm.com/docs/git-commit#_discussion
+    commit_encoding = None
+    try:
+        commit_encoding = run('git config i18n.commitencoding'.split())
+    except CalledProcessError as e:
+        if e.returncode != 1: # Config not defined
+            raise e
+    if not commit_encoding:
+        commit_encoding = 'UTF-8'
+
+    git_log = get_log(commit_encoding, args.git_log_args)
     if not git_log:
         return
 
@@ -49,8 +59,11 @@ def main():
 
 
 def run(*args, **kwargs):
+    from locale import getpreferredencoding
     from subprocess import check_output
-    return check_output(*args, **kwargs).strip().decode(ENC)
+    encoding = getpreferredencoding()
+    dbg('running command: {} (using {} encoding)', args[0], encoding)
+    return check_output(*args, **kwargs).strip().decode(encoding)
 
 
 def get_dist():
@@ -94,17 +107,17 @@ class Commit:
         return 'Commit({!r}, {!r})'.format(self.hash, self.message)
 
 
-def get_log(opts=()):
+def get_log(encoding, opts=()):
     from subprocess import Popen
 
     cmd = ('git', 'log') + tuple(opts) + ('--format=%h%x1f%D%x1f%s%x1e',)
-    dbg('running command: {}', cmd)
+    dbg('running command: {} (using {} encoding)', cmd, encoding)
     p = Popen(cmd, stdout=PIPE)
 
     log = []
     row = ''
     for l in p.stdout.readlines():
-        l = l.decode(ENC)
+        l = l.decode(encoding)
         # accumulate if the end of record is not found
         if not l.endswith('\x1e\n'):
             row += l
@@ -167,7 +180,7 @@ def parse_args():
     parser.add_argument('-i', '--initial-version',
             help="specifies an initial version (by default the tag of the last "
             "commit is used if present)")
-    parser.add_argument('-d', '--dist-name', default=get_dist(),
+    parser.add_argument('-d', '--dist-name',
             help="specifies the distribution name (by default obtained from "
             "lsb_release)")
     parser.add_argument('-u', '--urgency', default='medium',
@@ -180,6 +193,9 @@ def parse_args():
 
     global VERBOSE
     VERBOSE = args.verbose
+
+    if args.dist_name is None:
+        args.dist_name = get_dist()
 
     return parser, args
 

--- a/git-deblog
+++ b/git-deblog
@@ -172,8 +172,7 @@ def parse_args():
             "lsb_release)")
     parser.add_argument('-u', '--urgency', default='medium',
             choices='low medium high emergency critical'.split(),
-            help="specifies the distribution name (by default obtained from "
-            "lsb_release")
+            help="specifies the urgency of the update, in Debian terms")
     parser.add_argument('pkg_name', help="package name")
     parser.add_argument('git_log_args', nargs=REMAINDER,
             help="extra arguments to be passed to git log")

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -8,9 +8,6 @@
 rev_file=src/Version.d
 author="`git config user.name`"
 
-# Get compiler version
-compiler="`${DC:-dmd} | head -1`"
-
 # Get the current date (might be overridden by command-line options later)
 date=$(date -u +"%Y-%m-%d %H:%M:%S %Z")
 
@@ -72,6 +69,9 @@ then
     echo $version
     exit 0
 fi
+
+# Get compiler version
+compiler="`${DC:-dmd} | head -1`"
 
 template="$1"; shift
 

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -22,7 +22,7 @@ Options:
 
 -o FILE      Where to write the output (Version.d) file (default: $rev_file)
 -a AUTHOR    Author of the build (default: detected, currently $author)
--d DATE      Build date string (default: output of '$date_cmd')
+-d DATE      Build date string (default now: $date)
 -m MODULE    Module name to use in the module declaration (default: built from -o)
 -v           Be more verbose (print a message if the file was updated)
 -p           Only print this repository version and exit


### PR DESCRIPTION
```
* tag 'v1.7.3':
  mkversion: Fix default date in help
  mkversion: Don't run $DC unless is required
  git-deblog: Warn about wrong decoding
  git-deblog: Use i18n.logOutputEncoding instead of commitEncoding
  git-deblog: Expect UTF-8 encoding for commit message by default
  git-deblog: Fix wrongly copy&pasted help message
  git-deblog: Add missing `)` in help message
  git-deblog: Fix header when no tag in HEAD
  git-deblog: Add repr() to Commit and Tag objects
```