### PR TITLE
Don't fail if there are no submodules

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -178,7 +178,7 @@ endif
 # Location of the submodules (libraries the project depends on)
 SUBMODULES ?= $(shell git config -f $T/.gitmodules --name-only \
 			  --get-regexp'^submodule\.[^\.]+.*\.path$' | \
-			  xargs -n1 git config -f $T/.gitmodules --path --get)
+			  xargs -rn1 git config -f $T/.gitmodules --path --get)
 
 # Name of the build directory (to use when excluding some paths)
 BUILD_DIR_NAME ?= build


### PR DESCRIPTION
If there are no submodules, `xargs` will still call `git config` without
any variable name to get, resulting in an error. This commit fixes this
by passing `-r` (don't run if empty) to `xargs`.