### PR TITLE
mkpkg: Add path support to autodeps and new mapbins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -657,6 +657,9 @@ variable ``FUN``:
         function is tightly coupled to Debian packages for now. If a ``path``
         is given, then all the ``bin`` passed will be prepended with this
         ``path``.
+``mapbins(src, dst, bin[, ...])``
+        A very simple function that just returns a list with
+        ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.
 
 Generated packages will be stored in the ``$P`` directory (by default
 ``$G/pkg``. Since each package usually have a different name, as the version

--- a/README.rst
+++ b/README.rst
@@ -656,10 +656,12 @@ variable ``FUN``:
         multiple binaries to get a list of dependencies for all of them. This
         function is tightly coupled to Debian packages for now. If a ``path``
         is given, then all the ``bin`` passed will be prepended with this
-        ``path``.
+        ``path``. ``bin``\ s can be passed as multiple arguments or as one
+        list.
 ``mapbins(src, dst, bin[, ...])``
         A very simple function that just returns a list with
         ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.
+        ``bin``\ s can be passed as multiple arguments or as one list.
 
 Generated packages will be stored in the ``$P`` directory (by default
 ``$G/pkg``. Since each package usually have a different name, as the version

--- a/README.rst
+++ b/README.rst
@@ -601,9 +601,6 @@ particular target. This is a corner case and hopefully you won't need to use it.
 Packaging
 ---------
 
-.. warning:: This feature is still considered experimental. Use with care and
-             expect breakage.
-
 Makd supports a simple facility to make packages based on fpm_.  A simple
 wrapper program ``mkpkg`` is provided to ease the creation of scripts that use
 fpm_ to create packages.  The predefined ``pkg`` target will scan for ``*.pkg``

--- a/README.rst
+++ b/README.rst
@@ -649,12 +649,14 @@ passed to the ``mkpkg`` util. By default Makd pass the following variables:
 ``mkpkg`` also defines the following built-in functions in the special built-in
 variable ``FUN``:
 
-``autodeps(bin[, ...])``
+``autodeps(bin[, ...][, path=''])``
         returns a sorted ``list()`` of packages ``bin`` depends on based on the
         outcome of running the ``ldd`` utility and searching to which packages
         the libraries is linked belong to using ``dpkg``. You can specify
         multiple binaries to get a list of dependencies for all of them. This
-        function is tighly coupled to Debian packages for now.
+        function is tightly coupled to Debian packages for now. If a ``path``
+        is given, then all the ``bin`` passed will be prepended with this
+        ``path``.
 
 Generated packages will be stored in the ``$P`` directory (by default
 ``$G/pkg``. Since each package usually have a different name, as the version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,5 @@
 New Features
 ============
 
-* `mkpkg`: `FUN.autodeps()` now accepts multiple arguments. The set of dependencies for all of them are returned.
-
-* A new `graph-deps` target generates a dependencies graph (by default only with cyclic dependencies). To generate the graph the `dot` tool from the [graphviz](http://www.graphviz.org/) visualization software is used.
-
-* Add minimal and experimental support to create Non-Debian packages (in particular Arch Linux).
-
-* [d1to2fix v0.7.0](https://github.com/sociomantic-tsunami/d1to2fix/releases/tag/v0.7.0) new batch conversion is used if available.
+* Submodules are now parsed using `git config`, which should be more robust than
+  manual parsing.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@ New Features
 
 * `mkpkg`
 
-  - `FUN.autodeps()` now accepts a `path` to prepend to all passed binaries.
+  - `FUN.autodeps()` now accepts a `path` to prepend to all passed binaries and
+    can receive also the files as a single list instead of as multiple arguments.
 
   - A new function 'FUN.mapbins()` was added to ease specifying binaries to
     include in the package.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,4 +4,9 @@ New Features
 * Submodules are now parsed using `git config`, which should be more robust than
   manual parsing.
 
-* `mkpkg`: `FUN.autodeps()` now accepts a `path` to prepend to all passed binaries.
+* `mkpkg`
+
+  - `FUN.autodeps()` now accepts a `path` to prepend to all passed binaries.
+
+  - A new function 'FUN.mapbins()` was added to ease specifying binaries to
+    include in the package.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,5 @@ New Features
 
 * Submodules are now parsed using `git config`, which should be more robust than
   manual parsing.
+
+* `mkpkg`: `FUN.autodeps()` now accepts a `path` to prepend to all passed binaries.

--- a/mkpkg
+++ b/mkpkg
@@ -148,6 +148,11 @@ class Functions:
                 continue
         return sorted(deps)
 
+    def mapbins(self, src, dst, *bins):
+        return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
+                src=src, dst=dst, bin=b, suffix=pkg.vars['suffix'])
+                    for b in bins])
+
 
 class Package:
 

--- a/mkpkg
+++ b/mkpkg
@@ -118,18 +118,27 @@ class Functions:
         debugf("Output: {}", output)
         return regex.findall(output)
 
+    def _expand_list(self, files, path=''):
+        if path and not path.endswith('/'):
+            path += '/'
+        s = set()
+        for f in files:
+            if type(f) in (list, tuple, set, frozenset):
+                s.update(path + f)
+            else:
+                s.add(path + f)
+        return s
+
     def autodeps(self, *fnames, path=''):
         # XXX: Only debian packages supported for now
         if subprocess.call([ "dpkg", "--version"]) != 0:
             errf("'autodeps' is not yet supported on systems without dpkg")
             sys.exit(1)
 
-        if path and not path.endswith('/'):
-            path += '/'
-
         from itertools import chain
         deps = set()
-        parsed_commands = [self._parse_cmd('ldd', path + f) for f in fnames]
+        parsed_commands = [self._parse_cmd('ldd', f)
+                for f in self._expand_list(fnames, path)]
         for lib, lib_path in chain(*parsed_commands):
             if lib in self.autodeps_exclusions:
                 debugf("`{}` is in autodeps_exclusions, skipping...", lib)
@@ -151,7 +160,7 @@ class Functions:
     def mapbins(self, src, dst, *bins):
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=pkg.vars['suffix'])
-                    for b in bins])
+                    for b in self._expand_list(bins)])
 
 
 class Package:

--- a/mkpkg
+++ b/mkpkg
@@ -118,28 +118,33 @@ class Functions:
         debugf("Output: {}", output)
         return regex.findall(output)
 
-    def autodeps(self, *fnames):
+    def autodeps(self, *fnames, path=''):
         # XXX: Only debian packages supported for now
         if subprocess.call([ "dpkg", "--version"]) != 0:
             errf("'autodeps' is not yet supported on systems without dpkg")
             sys.exit(1)
 
+        if path and not path.endswith('/'):
+            path += '/'
+
         from itertools import chain
         deps = set()
-        for lib, path in chain(*[self._parse_cmd('ldd', f) for f in fnames]):
+        parsed_commands = [self._parse_cmd('ldd', path + f) for f in fnames]
+        for lib, lib_path in chain(*parsed_commands):
             if lib in self.autodeps_exclusions:
                 debugf("`{}` is in autodeps_exclusions, skipping...", lib)
                 continue
-            if path == '' or path == 'not found':
+            if lib_path == '' or lib_path == 'not found':
                 warnf("`ldd` returned '{}' for library `{}`, skipping "
-                        "automatic dependency calculation for it...", path, lib)
+                        "automatic dependency calculation for it...",
+                        lib_path, lib)
                 continue
             try:
-                deps.add(self._parse_cmd('dpkg', '-S', path)[0])
+                deps.add(self._parse_cmd('dpkg', '-S', lib_path)[0])
             except subprocess.SubprocessError as e:
                 warnf("Error looking up library `{}` (`{}`) via `dpkg`, "
                         "skipping automatic dependency calculation for it: {}",
-                        lib, path, e)
+                        lib, lib_path, e)
                 continue
         return sorted(deps)
 


### PR DESCRIPTION
There is a very common pattern when using autodeps, passing a bunch of
files that are in the same location, which usually means repeating the
base path several times.

This commit add the option to pass a path to autodeps to do that
automatically, for example:

    FUN.autodeps('file1', 'file2', path='build')