### PR TITLE
mkpkg: Fix _expand_list (autodeps and mapbins)

### DIFF
--- a/mkpkg
+++ b/mkpkg
@@ -124,7 +124,7 @@ class Functions:
         s = set()
         for f in files:
             if type(f) in (list, tuple, set, frozenset):
-                s.update(path + f)
+                s.update([path + ff for ff in f])
             else:
                 s.add(path + f)
         return s


### PR DESCRIPTION
The _expand_list was misbehaving when passing a list to autodeps and
mapbins instead of using the old way to pass multiple arguments.

At least this is not a regression, it just make the new feature
unusable.

We **really** need to start thinking about adding tests to this :(