### PR TITLE
Replace VAR.name -> VAR.fullname and add VAR.shortname

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -456,6 +456,7 @@ $O/pkg-%.stamp: $(PKG)/%.pkg
 		$(PKG_DEFAULTS) \
 		-d suffix="$(PKG_SUFFIX)" -d version="$(PKGVERSION)" \
 		-d builddir="$G" -d bindir="$B" -d name="$*$(PKG_SUFFIX)" \
+		-d fullname="$*$(PKG_SUFFIX)" -d shortname="$*" \
 		$<,$<,mkpkg)
 	$Vtouch $@
 

--- a/README.rst
+++ b/README.rst
@@ -652,9 +652,15 @@ These files are expected to be Python scripts defining two variables:
 An extra built-in variable will be available, ``VAR``, containing variables
 passed to the ``mkpkg`` util. By default Makd pass the following variables:
 
-``name``
-        name of the package as calculated from the ``.pkg`` file, including the
-        ``SUFFIX``.
+``shortname``
+        name of the package as calculated from the ``.pkg`` file.
+
+``suffix``
+        a suffix to add to the package name to support installing multiple
+        versions simultaneously (see `Package suffix`_ for details).
+
+``fullname``
+        ``shortname`` with the ``suffix`` appended to it for conveniece.
 
 ``version``
         package version number as defined by ``PKGVERSION``.
@@ -664,10 +670,6 @@ passed to the ``mkpkg`` util. By default Makd pass the following variables:
 
 ``bindir``
         directory where the built binaries are stored.
-
-``suffix``
-        a suffix to add to the package name to support installing multiple
-        versions simultaneously (see `Package suffix`_ for details).
 
 ``lsb_release``
         Debian ``lsb_release -uc`` content (distribution name).
@@ -760,7 +762,7 @@ For convenience, here is a simple example:
 
         OPTS.update(
 
-          name = VAR.name,
+          name = VAR.fullname,
 
           description = '''\
         Test package packing some daemon
@@ -779,7 +781,7 @@ For convenience, here is a simple example:
         )
 
         ARGS = VAR.mapbins(VAR.bindir, '/usr/sbin', bins) + [
-          'README.rst=/usr/share/doc/' + VAR.name '/',
+          'README.rst=/usr/share/doc/' + VAR.fullname '/',
         ]
 
 ``$P/client.pkg``:
@@ -792,7 +794,7 @@ For convenience, here is a simple example:
 
         OPTS.update(
 
-          name = VAR.name,
+          name = VAR.fullname,
 
           description = '''Test package packing some daemon
         This is an extended package description with multiple lines

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
 New Features
 ============
 
+* `VAR.fullname` `VAR.shortname`
+
+  Added new variables, available in package definition files. `VAR.fullname`
+  replaces the old `VAR.name` to make it more explicit, `VAR.shortname` contains
+  only the package name, without the `VAR.suffix`.
+
+Deprecations
+============
+
+* `VAR.name` is deprecated, please use `VAR.fullname` instead.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,3 @@
 New Features
 ============
 
-* Submodules are now parsed using `git config`, which should be more robust than
-  manual parsing.
-
-* `mkpkg`
-
-  - `FUN.autodeps()` now accepts a `path` to prepend to all passed binaries and
-    can receive also the files as a single list instead of as multiple arguments.
-
-  - A new function 'FUN.mapbins()` was added to ease specifying binaries to
-    include in the package.
-
-Milestone: https://github.com/sociomantic-tsunami/makd/milestone/12?closed=1


### PR DESCRIPTION
New variables, available in package definition files.

`VAR.fullname` replaces the old `VAR.name` to make it more explicit, `VAR.shortname` contains only the package name, without the `VAR.suffix`.