### PR TITLE
Remove unused D_GC variable and documentation

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -111,11 +111,6 @@ endif
 # Default rdmd binary to use (same as with dmd)
 RDMD ?= rdmd
 
-# Garbage Collector to use
-# (exported because other programs might use the variable)
-D_GC ?= cdgc
-export D_GC
-
 # Default documentation generator tool to use (harbored-mod)
 HMOD ?= hmod
 

--- a/README.rst
+++ b/README.rst
@@ -361,7 +361,6 @@ Variables you might want to override
 * Program location variables: ``DC`` is the D compiler to use, you can build
   your project with a different DMD by using ``make
   DC=/usr/bin/experimental-dmd`` for example. Same for ``RDMD`` and ``FPM``.
-* ``D_GC`` to change the default (cdgc) GC implementation to use.
 * Less likely you might want to override the ``DFLAGS``, ``RDMDFLAGS`` or
   ``FPMFLAGS``, but usually there are better methods to do that instead.
 * ``TEST_FILTER_OUT`` to exclude some files from the unit tests or integration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,6 @@ Migration Instructions
 
 * The `Version` alias to `versionInfo` provided by the `Version` module has been removed.
   All remaining usage can be replaced with `versionInfo`.
+
+* The `D_GC` variable was removed as it wasn't used internally anymore.
+  If you made use of it anywhere, you should define it yourself (in `Config.mak` for example) from now on.


### PR DESCRIPTION
This doesn't seem to be used anywhere, hence why I targeted v1.x.x. Let me know if you want to re-target.

OT: v1.x.x should probably be merged into v2.x.x (which is 50 commits behind).