### PR TITLE
Add a new mapfiles function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -686,6 +686,13 @@ variable ``FUN``:
         is given, then all the ``bin`` passed will be prepended with this
         ``path``. ``bin``\ s can be passed as multiple arguments or as one
         list.
+``mapfiles(src, dst, file[, ...][, append_suffix=True])``
+        A very simple function that just returns a list with
+        ``{src}/{file}={dst}/{file}{VAR.suffix}`` for each ``file`` passed.
+        ``file``\ s can be passed as multiple arguments or as one list. A named
+        argument ``append_suffix`` can be passed at the end to control whether
+        ``VAR.suffix`` is appended to each destination file. ``append_suffix``
+        defaults to ``True`` if not given.
 ``mapbins(src, dst, bin[, ...])``
         A very simple function that just returns a list with
         ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.

--- a/README.rst
+++ b/README.rst
@@ -693,10 +693,6 @@ variable ``FUN``:
         argument ``append_suffix`` can be passed at the end to control whether
         ``VAR.suffix`` is appended to each destination file. ``append_suffix``
         defaults to ``True`` if not given.
-``mapbins(src, dst, bin[, ...])``
-        A very simple function that just returns a list with
-        ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.
-        ``bin``\ s can be passed as multiple arguments or as one list.
 ``desc(OPTS, [type[, prolog[, epilog]]])``
         A simple function to customize ``OPTS['description']``. It can add an
         optional ``type`` of package (will append `` (<type>)`` to the first
@@ -805,7 +801,7 @@ For convenience, here is a simple example:
 
         )
 
-        ARGS = FUN.mapbins(VAR.bindir, '/usr/sbin', bins) + [
+        ARGS = FUN.mapfiles(VAR.bindir, '/usr/sbin', bins) + [
           'README.rst=/usr/share/doc/' + VAR.fullname '/',
         ]
 
@@ -829,9 +825,8 @@ For convenience, here is a simple example:
           depends = FUN.autodeps(bins, path=VAR.bindir),
         )
 
-        ARGS = FUN.mapbins(VAR.bindir, '/usr/bin', bins) + [
-          'util.conf=/etc/',
-        ]
+        ARGS = FUN.mapfiles(VAR.bindir, '/usr/bin', bins)
+        ARGS += FUN.mapfiles('.', '/etc', 'util.conf', append_suffix=False)
 
 Suppose that the targets ``daemon`` and ``client`` build the binaries
 ``daemon``, ``admtool``, ``util1`` and ``client``, ``clitool`` respectively,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,3 +24,5 @@ Deprecations
 ============
 
 * `VAR.name` is deprecated, please use `VAR.fullname` instead.
+
+* `FUN.mapbins()` is deprecated, please use `FUN.mapfiles()` instead.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,11 @@ New Features
   description), `prolog` (inserted before the long description) and an `epilog`
   (appended at the end of the long description.
 
+* `FUN.mapfiles()`
+
+  A simple function to ease specifying files to include in the package (with the
+  ability to control whether `VAR.suffix` is appended to each destination file
+  using the named argument `append_suffix`).
 
 Deprecations
 ============

--- a/mkpkg
+++ b/mkpkg
@@ -166,6 +166,7 @@ class Functions:
                     for b in self._expand_list(bins)])
 
     def mapbins(self, src, dst, *bins):
+        warnf("'FUN.mapbins()' is deprecated, please use 'FUN.mapfiles()' instead")
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=self.pkg.vars['suffix'])
                     for b in self._expand_list(bins)])

--- a/mkpkg
+++ b/mkpkg
@@ -158,6 +158,13 @@ class Functions:
                 continue
         return sorted(deps)
 
+    def mapfiles(self, src, dst, *bins, **kwargs):
+        append_suffix = kwargs.get('append_suffix', True)
+        suffix = self.pkg.vars['suffix'] if append_suffix else ''
+        return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
+                src=src, dst=dst, bin=b, suffix=suffix)
+                    for b in self._expand_list(bins)])
+
     def mapbins(self, src, dst, *bins):
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=self.pkg.vars['suffix'])


### PR DESCRIPTION
The current `mapbins()` function is a convenient way to map local files into the package, but there is no reason for it to be limited to only mapping binaries. For this reason, a new `mapfiles()` function is introduced.

However, when mapping non-binaries, `VAR.suffix` may not be needed to be appended. So we need to also provide a way to control this.