### PR TITLE
mkpkg: Add FUN.desc()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -690,6 +690,25 @@ variable ``FUN``:
         A very simple function that just returns a list with
         ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.
         ``bin``\ s can be passed as multiple arguments or as one list.
+``desc(OPTS, [type[, prolog[, epilog]]])``
+        A simple function to customize ``OPTS['description']``. It can add an
+        optional ``type`` of package (will append `` (<type>)`` to the first
+        line (short description), ``prolog`` (inserted before the long
+        description) and an ``epilog`` (appended at the end of the long
+        description. To use only one of them, you can use Python's keyword
+        arguments syntax. Examples:
+
+        .. code:: py
+
+                FUN.desc(OPTS, 'common files', 'These are just config files',
+                    'Part of whatever') # All specified
+                FUN.desc(OPTS, epilog='Just an epilog')
+                FUN.desc(OPTS, 'a type', epilog='And an epilog')
+                FUN.desc(OPTS, prolog='A prolog',
+                    epilog='And an epilog, but no type')
+
+        Note that ``OPTS['desciption']`` must be defined and hold a non-empty
+        string.
 
 Generated packages will be stored in the ``$P`` directory (by default
 ``$G/pkg``. Since each package usually have a different name, as the version
@@ -747,6 +766,12 @@ For convenience, here is a simple example:
 
         # This is a normal python module defining some defaults
         OPTS = dict(
+          description = '''\
+        Test package packing some daemon
+        This is an extended package description with multiple lines
+
+        This is a longer paragraph in the package description that
+        can span multiple lines.''',
           url = 'https://github.com/sociomantic/makd',
           maintainer = 'Sociomantic Labs GmbH <info@sociomantic.com>',
           vendor = 'Sociomantic Labs GmbH',
@@ -763,13 +788,6 @@ For convenience, here is a simple example:
         OPTS.update(
 
           name = VAR.fullname,
-
-          description = '''\
-        Test package packing some daemon
-        This is an extended package description with multiple lines
-
-        This is a longer paragraph in the package description that
-        can span multiple lines.''',
 
           category = 'net',
 
@@ -796,13 +814,8 @@ For convenience, here is a simple example:
 
           name = VAR.fullname,
 
-          description = '''Test package packing some daemon
-        This is an extended package description with multiple lines
-
-        All the lines that starts with a space or tab will be joined
-        together when passed to fpm (and the leading spaces will be
-        removed).
-        '''
+          description = FUN.desc(OPTS, 'tools', epilog='These are just ' +
+            'utilities for the daemon package'),
 
           category = 'net',
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,14 @@ New Features
   replaces the old `VAR.name` to make it more explicit, `VAR.shortname` contains
   only the package name, without the `VAR.suffix`.
 
+* `FUN.desc()`
+
+  A simple function to customize `OPTS['description']`. It can add an optional
+  `type` of package (will append ` (<type>)` to the first line (short
+  description), `prolog` (inserted before the long description) and an `epilog`
+  (appended at the end of the long description.
+
+
 Deprecations
 ============
 

--- a/mkpkg
+++ b/mkpkg
@@ -163,6 +163,27 @@ class Functions:
                 src=src, dst=dst, bin=b, suffix=self.pkg.vars['suffix'])
                     for b in self._expand_list(bins)])
 
+    def desc(self, OPTS, type='', prolog='', epilog=''):
+        try:
+            d = OPTS['description']
+        except (TypeError, KeyError):
+            die("FUN.desc() requires an OPTS['description'] to be defined")
+        try:
+            d = d.splitlines()
+            firstline = d[0]
+        except (AttributeError, KeyError):
+            die("FUN.desc() requires an OPTS['description'] that is a "
+                    "non-empty string")
+        if type:
+            type = ' (' + type + ')'
+        type += '\n'
+        if prolog:
+            prolog += '\n\n'
+        if epilog:
+            epilog = '\n\n' + epilog
+        rest = '\n'.join(d[1:])
+        return firstline + type + prolog + rest + epilog
+
 
 class Package:
 


### PR DESCRIPTION
A very common pattern when creating packages for a multi-package project is to have a `pkg/defaults.py` file defining the common fields like a description.

The problem is, customizing this description in real package definition files where the defaults are imported is cryptic and complicated for users not familiar with Python.

This new functions makes it easier to customize general descriptions shared by several packages in multi-package projects.