### PR TITLE
Merge tag 'v1.9.0' into v2.x.x

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -447,7 +447,7 @@ pkg: $(patsubst $(PKG)/%.pkg,$O/pkg-%.stamp,$(wildcard $(PKG)/*.pkg))
 # Target to build a package based on the fpm definition (old packages are
 # removed to avoid infinite pollution of the build directory, as every package
 # is a different file)
-$O/pkg-%.stamp: $(PKG)/%.pkg
+$O/pkg-%.stamp: $(PKG)/%.pkg $G/pkg-flags
 	$(PKG_PREBUILD)
 	$(call exec,PYTHONDONTWRITEBYTECODE=1 $(MAKD_PATH)/mkpkg \
 		$(if $V,,-vv) -D-p"$P" -F "$(FPM)" \
@@ -612,6 +612,17 @@ setup_flag_files__ := $(setup_flag_files__)$(call gen_rebuild_flags, \
 
 # Print any generated message (if verbose)
 $(if $V,$(if $(setup_flag_files__), \
+	$(info !! Flags or commands changed:$(setup_flag_files__) re-building \
+			affected files...)))
+
+# Same for packages
+PKG.FLAGS := $(call varcat,PKG_SUFFIX FPM)
+
+setup_pkg_flag_files__ := $(setup_pkg_flag_files__)$(call gen_rebuild_flags, \
+	$G/pkg-flags, $(PKG.FLAGS),Packaging flags)
+
+# Print any generated message (if verbose)
+$(if $V,$(if $(setup_pkg_flag_files__), \
 	$(info !! Flags or commands changed:$(setup_flag_files__) re-building \
 			affected files...)))
 

--- a/README.rst
+++ b/README.rst
@@ -686,6 +686,13 @@ variable ``FUN``:
         is given, then all the ``bin`` passed will be prepended with this
         ``path``. ``bin``\ s can be passed as multiple arguments or as one
         list.
+``mapfiles(src, dst, file[, ...][, append_suffix=True])``
+        A very simple function that just returns a list with
+        ``{src}/{file}={dst}/{file}{VAR.suffix}`` for each ``file`` passed.
+        ``file``\ s can be passed as multiple arguments or as one list. A named
+        argument ``append_suffix`` can be passed at the end to control whether
+        ``VAR.suffix`` is appended to each destination file. ``append_suffix``
+        defaults to ``True`` if not given.
 ``mapbins(src, dst, bin[, ...])``
         A very simple function that just returns a list with
         ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.

--- a/README.rst
+++ b/README.rst
@@ -752,8 +752,8 @@ For convenience, here is a simple example:
 
         )
 
-        ARGS = VAR.mapbins(VAR.bindir, '/usr/sbin', bins) + [
-          'README.rst=/usr/share/doc/' + VAR.name '/',
+        ARGS = FUN.mapbins(VAR.bindir, '/usr/sbin', bins) + [
+          'README.rst=/usr/share/doc/' + VAR.name + '/',
         ]
 
 ``$P/client.pkg``:
@@ -781,7 +781,7 @@ For convenience, here is a simple example:
           depends = FUN.autodeps(bins, path=VAR.bindir),
         )
 
-        ARGS = VAR.mapbins(VAR.bindir, '/usr/bin', bins) + [
+        ARGS = FUN.mapbins(VAR.bindir, '/usr/bin', bins) + [
           'util.conf=/etc/',
         ]
 

--- a/README.rst
+++ b/README.rst
@@ -693,10 +693,6 @@ variable ``FUN``:
         argument ``append_suffix`` can be passed at the end to control whether
         ``VAR.suffix`` is appended to each destination file. ``append_suffix``
         defaults to ``True`` if not given.
-``mapbins(src, dst, bin[, ...])``
-        A very simple function that just returns a list with
-        ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.
-        ``bin``\ s can be passed as multiple arguments or as one list.
 ``desc(OPTS, [type[, prolog[, epilog]]])``
         A simple function to customize ``OPTS['description']``. It can add an
         optional ``type`` of package (will append `` (<type>)`` to the first
@@ -805,7 +801,7 @@ For convenience, here is a simple example:
 
         )
 
-        ARGS = FUN.mapbins(VAR.bindir, '/usr/sbin', bins) + [
+        ARGS = FUN.mapfiles(VAR.bindir, '/usr/sbin', bins) + [
           'README.rst=/usr/share/doc/' + VAR.fullname '/',
         ]
 
@@ -829,9 +825,8 @@ For convenience, here is a simple example:
           depends = FUN.autodeps(bins, path=VAR.bindir),
         )
 
-        ARGS = FUN.mapbins(VAR.bindir, '/usr/bin', bins) + [
-          'util.conf=/etc/',
-        ]
+        ARGS = FUN.mapfiles(VAR.bindir, '/usr/bin', bins)
+        ARGS += FUN.mapfiles('.', '/etc', 'util.conf', append_suffix=False)
 
 Suppose that the targets ``daemon`` and ``client`` build the binaries
 ``daemon``, ``admtool``, ``util1`` and ``client``, ``clitool`` respectively,

--- a/README.rst
+++ b/README.rst
@@ -690,6 +690,25 @@ variable ``FUN``:
         A very simple function that just returns a list with
         ``{src}/{bin}={dst}/{bin}{VAR.suffix}`` for each ``bin`` passed.
         ``bin``\ s can be passed as multiple arguments or as one list.
+``desc(OPTS, [type[, prolog[, epilog]]])``
+        A simple function to customize ``OPTS['description']``. It can add an
+        optional ``type`` of package (will append `` (<type>)`` to the first
+        line (short description), ``prolog`` (inserted before the long
+        description) and an ``epilog`` (appended at the end of the long
+        description. To use only one of them, you can use Python's keyword
+        arguments syntax. Examples:
+
+        .. code:: py
+
+                FUN.desc(OPTS, 'common files', 'These are just config files',
+                    'Part of whatever') # All specified
+                FUN.desc(OPTS, epilog='Just an epilog')
+                FUN.desc(OPTS, 'a type', epilog='And an epilog')
+                FUN.desc(OPTS, prolog='A prolog',
+                    epilog='And an epilog, but no type')
+
+        Note that ``OPTS['desciption']`` must be defined and hold a non-empty
+        string.
 
 Generated packages will be stored in the ``$P`` directory (by default
 ``$G/pkg``. Since each package usually have a different name, as the version
@@ -747,6 +766,12 @@ For convenience, here is a simple example:
 
         # This is a normal python module defining some defaults
         OPTS = dict(
+          description = '''\
+        Test package packing some daemon
+        This is an extended package description with multiple lines
+
+        This is a longer paragraph in the package description that
+        can span multiple lines.''',
           url = 'https://github.com/sociomantic/makd',
           maintainer = 'Sociomantic Labs GmbH <info@sociomantic.com>',
           vendor = 'Sociomantic Labs GmbH',
@@ -763,13 +788,6 @@ For convenience, here is a simple example:
         OPTS.update(
 
           name = VAR.fullname,
-
-          description = '''\
-        Test package packing some daemon
-        This is an extended package description with multiple lines
-
-        This is a longer paragraph in the package description that
-        can span multiple lines.''',
 
           category = 'net',
 
@@ -796,13 +814,8 @@ For convenience, here is a simple example:
 
           name = VAR.fullname,
 
-          description = '''Test package packing some daemon
-        This is an extended package description with multiple lines
-
-        All the lines that starts with a space or tab will be joined
-        together when passed to fpm (and the leading spaces will be
-        removed).
-        '''
+          description = FUN.desc(OPTS, 'tools', epilog='These are just ' +
+            'utilities for the daemon package'),
 
           category = 'net',
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,3 +24,5 @@ Deprecations
 ============
 
 * `VAR.name` is deprecated, please use `VAR.fullname` instead.
+
+* `FUN.mapbins()` is deprecated, please use `FUN.mapfiles()` instead.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,11 @@ New Features
   description), `prolog` (inserted before the long description) and an `epilog`
   (appended at the end of the long description.
 
+* `FUN.mapfiles()`
+
+  A simple function to ease specifying files to include in the package (with the
+  ability to control whether `VAR.suffix` is appended to each destination file
+  using the named argument `append_suffix`).
 
 Deprecations
 ============

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,5 +9,5 @@ New Features
   - `FUN.autodeps()` now accepts a `path` to prepend to all passed binaries and
     can receive also the files as a single list instead of as multiple arguments.
 
-  - A new function 'FUN.mapbins()` was added to ease specifying binaries to
+  - A new function `FUN.mapbins()` was added to ease specifying binaries to
     include in the package.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,14 @@ New Features
   replaces the old `VAR.name` to make it more explicit, `VAR.shortname` contains
   only the package name, without the `VAR.suffix`.
 
+* `FUN.desc()`
+
+  A simple function to customize `OPTS['description']`. It can add an optional
+  `type` of package (will append ` (<type>)` to the first line (short
+  description), `prolog` (inserted before the long description) and an `epilog`
+  (appended at the end of the long description.
+
+
 Deprecations
 ============
 

--- a/mkpkg
+++ b/mkpkg
@@ -166,6 +166,7 @@ class Functions:
                     for b in self._expand_list(bins)])
 
     def mapbins(self, src, dst, *bins):
+        warnf("'FUN.mapbins()' is deprecated, please use 'FUN.mapfiles()' instead")
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=self.pkg.vars['suffix'])
                     for b in self._expand_list(bins)])

--- a/mkpkg
+++ b/mkpkg
@@ -163,6 +163,27 @@ class Functions:
                 src=src, dst=dst, bin=b, suffix=self.pkg.vars['suffix'])
                     for b in self._expand_list(bins)])
 
+    def desc(self, OPTS, type='', prolog='', epilog=''):
+        try:
+            d = OPTS['description']
+        except (TypeError, KeyError):
+            die("FUN.desc() requires an OPTS['description'] to be defined")
+        try:
+            d = d.splitlines()
+            firstline = d[0]
+        except (AttributeError, KeyError):
+            die("FUN.desc() requires an OPTS['description'] that is a "
+                    "non-empty string")
+        if type:
+            type = ' (' + type + ')'
+        type += '\n'
+        if prolog:
+            prolog += '\n\n'
+        if epilog:
+            epilog = '\n\n' + epilog
+        rest = '\n'.join(d[1:])
+        return firstline + type + prolog + rest + epilog
+
 
 class Package:
 

--- a/mkpkg
+++ b/mkpkg
@@ -158,6 +158,13 @@ class Functions:
                 continue
         return sorted(deps)
 
+    def mapfiles(self, src, dst, *bins, **kwargs):
+        append_suffix = kwargs.get('append_suffix', True)
+        suffix = self.pkg.vars['suffix'] if append_suffix else ''
+        return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
+                src=src, dst=dst, bin=b, suffix=suffix)
+                    for b in self._expand_list(bins)])
+
     def mapbins(self, src, dst, *bins):
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=self.pkg.vars['suffix'])


### PR DESCRIPTION
* tag 'v1.9.0':
  Deprecate FUN.mapbins in favour of FUN.mapfiles
  mkpkg: Add new function FUN.mapfiles
  pkg: Force rebuild if PKG_SUFFIX changed
  mkpkg: Add FUN.desc()
  Fix typos
  Minor formatting fix