### PR TITLE
pkg: Make OPTS and ARGS built-in

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -632,7 +632,11 @@ fpm_ to create packages.  The predefined ``pkg`` target will scan for ``*.pkg``
 files in the ``$(PKG)`` directory (by default ``$T/pkg``) and then invoke
 ``mkpkg`` with them.
 
-These files are expected to be Python scripts defining two variables:
+These files are expected to be Python scripts. They have some pre-defined
+built-in variables, some of which the user is expected to fill and some of
+which are tools for the user to define packages.
+
+These are the built-in variables that the user should fill:
 
 ``OPTS``
         a ``dict()`` (associative array) where each item will be mapped to
@@ -648,8 +652,12 @@ These files are expected to be Python scripts defining two variables:
         a ``list()`` (array) to pass to fpm_ as positional arguments (usually the
         list of files to include in the package).
 
+These variables should never be rebound (never assign to them like ``OPTS
+= dict(...)``), you always need to update them instead (normally using
+``OPTS.update(...)`` and ``ARGS.extend([...])``).
+
 An extra built-in variable will be available, ``VAR``, containing variables
-passed to the ``mkpkg`` util. By default Makd pass the following variables:
+passed to the ``mkpkg`` util. By default Makd passes the following variables:
 
 ``shortname``
         name of the package as calculated from the ``.pkg`` file.
@@ -767,7 +775,7 @@ For convenience, here is a simple example:
 .. code:: py
 
         # This is a normal python module defining some defaults
-        OPTS = dict(
+        OPTS.update(
           description = '''\
         Test package packing some daemon
         This is an extended package description with multiple lines
@@ -783,7 +791,7 @@ For convenience, here is a simple example:
 
 .. code:: py
 
-        from defaults import OPTS
+        import defaults
 
         bins = 'daemon admtool util1'
 
@@ -800,15 +808,15 @@ For convenience, here is a simple example:
 
         )
 
-        ARGS = FUN.mapfiles(VAR.bindir, '/usr/sbin', bins) + [
+        ARGS.extend(FUN.mapfiles(VAR.bindir, '/usr/sbin', bins) + [
           'README.rst=/usr/share/doc/' + VAR.fullname '/',
-        ]
+        ])
 
 ``$P/client.pkg``:
 
 .. code:: py
 
-        from defaults import OPTS
+        import defaults
 
         bins = 'client clitool'
 
@@ -824,8 +832,8 @@ For convenience, here is a simple example:
           depends = FUN.autodeps(bins, path=VAR.bindir),
         )
 
-        ARGS = FUN.mapfiles(VAR.bindir, '/usr/bin', bins)
-        ARGS += FUN.mapfiles('.', '/etc', 'util.conf', append_suffix=False)
+        ARGS.extend(FUN.mapfiles(VAR.bindir, '/usr/bin', bins))
+        ARGS.extend(FUN.mapfiles('.', '/etc', 'util.conf', append_suffix=False))
 
 Suppose that the targets ``daemon`` and ``client`` build the binaries
 ``daemon``, ``admtool``, ``util1`` and ``client``, ``clitool`` respectively,

--- a/README.rst
+++ b/README.rst
@@ -700,7 +700,7 @@ variable ``FUN``:
         argument ``append_suffix`` can be passed at the end to control whether
         ``VAR.suffix`` is appended to each destination file. ``append_suffix``
         defaults to ``True`` if not given.
-``desc(OPTS, [type[, prolog[, epilog]]])``
+``desc([type[, prolog[, epilog]]])``
         A simple function to customize ``OPTS['description']``. It can add an
         optional ``type`` of package (will append `` (<type>)`` to the first
         line (short description), ``prolog`` (inserted before the long
@@ -710,11 +710,11 @@ variable ``FUN``:
 
         .. code:: py
 
-                FUN.desc(OPTS, 'common files', 'These are just config files',
+                FUN.desc('common files', 'These are just config files',
                     'Part of whatever') # All specified
-                FUN.desc(OPTS, epilog='Just an epilog')
-                FUN.desc(OPTS, 'a type', epilog='And an epilog')
-                FUN.desc(OPTS, prolog='A prolog',
+                FUN.desc(epilog='Just an epilog')
+                FUN.desc('a type', epilog='And an epilog')
+                FUN.desc(prolog='A prolog',
                     epilog='And an epilog, but no type')
 
         Note that ``OPTS['desciption']`` must be defined and hold a non-empty
@@ -824,7 +824,7 @@ For convenience, here is a simple example:
 
           name = VAR.fullname,
 
-          description = FUN.desc(OPTS, 'tools', epilog='These are just ' +
+          description = FUN.desc('tools', epilog='These are just ' +
             'utilities for the daemon package'),
 
           category = 'net',

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,3 +12,20 @@ Migration Instructions
 
 * The deprecated packaging variable `VAR.name` was removed, use `VAR.fullname`
   instead.
+
+* The ``OPTS`` and ``ARGS`` variables used when defining packages have become
+  built-ins now, so they should be modified **in-place** (using
+  ``OPTS.update()``, ``OPTS['xxx']``, and ``ARGS.extend()``, ``ARGS.append()``
+  or any other functions that mutates the object).
+
+  You should **NEVER** re-bind (re-assign) these variables (``OPTS = ...``,
+  ``ARGS = ...`` or even ``ARGS += ...`` and any other operators that re-assign
+  the variable are forbidden).
+
+  Also, if you are using a ``defaults.py`` file, now just use ``ìmport
+  defaults`` in ``.pkg`` files using it, don't explicitly import the ``OPTS``
+  and ``ARGS`` symbols anymore:
+
+  Change ``from defaults import OPTS, ARGS`` to ``import defaults``.
+
+  This change helps making much compact utility functions.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,12 @@
 Migration Instructions
 ======================
 
-* The `Version` alias to `versionInfo` provided by the `Version` module has been removed.
-  All remaining usage can be replaced with `versionInfo`.
+* The `Version` alias to `versionInfo` provided by the `Version` module has been
+  removed. All remaining usage can be replaced with `versionInfo`.
 
 * The `D_GC` variable was removed as it wasn't used internally anymore.
-  If you made use of it anywhere, you should define it yourself (in `Config.mak` for example) from now on.
+  If you made use of it anywhere, you should define it yourself (in `Config.mak`
+  for example) from now on.
 
 * The deprecated packaging function `FUN.mapbins()` was removed, use
   `FUN.mapfiles()` instead.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,4 +28,11 @@ Migration Instructions
 
   Change ``from defaults import OPTS, ARGS`` to ``import defaults``.
 
-  This change helps making much compact utility functions.
+  This change helps making much compact utility functions. See changes on
+  ``FUN.desc()``.
+
+* The ``FUN.desc()`` function for defining packages now doesn't take ``OPTS`` as
+  an argument, it just gets the ``OPTS['description']`` from the built-in
+  ``OPTS``.
+
+  Change ``FUN.desc(OPTS, ...)`` to ``FUN.desc(...)``.

--- a/mkpkg
+++ b/mkpkg
@@ -213,6 +213,8 @@ class Package:
     def load(self, fname):
         import runpy
         global __builtins__
+        __builtins__.OPTS = {}
+        __builtins__.ARGS = []
         __builtins__.VAR = AttrDict(self.vars)
         __builtins__.FUN = self.functions
         sys.path.insert(0, os.path.dirname(fname))
@@ -224,10 +226,15 @@ class Package:
         except Exception as e:
             die("can't load package definition file '{}'", fname, _tb=True,
                     _remove_tb=4)
+        else:
+            pkg['OPTS'] = __builtins__.OPTS
+            pkg['ARGS'] = __builtins__.ARGS
         finally:
             sys.path.pop(0)
             del __builtins__.VAR
             del __builtins__.FUN
+            del __builtins__.OPTS
+            del __builtins__.ARGS
 
         def checked_get(name, type):
             if name not in pkg:

--- a/mkpkg
+++ b/mkpkg
@@ -165,7 +165,8 @@ class Functions:
                 src=src, dst=dst, bin=b, suffix=suffix)
                     for b in self._expand_list(bins)])
 
-    def desc(self, OPTS, type='', prolog='', epilog=''):
+    def desc(self, type='', prolog='', epilog=''):
+        global OPTS
         try:
             d = OPTS['description']
         except (TypeError, KeyError):


### PR DESCRIPTION
Making OPTS and ARGS built-in variables allows built-in functions provided
by mkpkg to operate over them, thus allowing mkpkg to define more powerful
tools to users.

This also changes ``FUN.desc()`` not to take ``OPTS`` as an argument
anymore.