### PR TITLE
mkpkg: Add ability to map entire directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ also supported (see under `D2 support`_ for details).
 Versioning
 ----------
 
-MakD complies with `Netptune <https://github.com/sociomantic-tsunami/neptune>`_
+MakD complies with `Neptune <https://github.com/sociomantic-tsunami/neptune>`_
 for versioning.
 
 Support Guarantees

--- a/README.rst
+++ b/README.rst
@@ -686,13 +686,17 @@ variable ``FUN``:
         is given, then all the ``bin`` passed will be prepended with this
         ``path``. ``bin``\ s can be passed as multiple arguments or as one
         list.
-``mapfiles(src, dst, file[, ...][, append_suffix=True])``
+``mapfiles(src, dst, [file[, ...]][, append_suffix=True])``
         A very simple function that just returns a list with
         ``{src}/{file}={dst}/{file}{VAR.suffix}`` for each ``file`` passed.
-        ``file``\ s can be passed as multiple arguments or as one list. A named
-        argument ``append_suffix`` can be passed at the end to control whether
-        ``VAR.suffix`` is appended to each destination file. ``append_suffix``
-        defaults to ``True`` if not given.
+        ``file``\ s can be passed as multiple arguments or as one list. If no
+        ``file``\ s are passed, a simple ``{src}/={dst}/`` mapping is returned
+        which results in the directory structure under ``src`` (including all
+        contained files) being replicated as-is from the local filesystem into
+        ``dst`` within the package. A named argument ``append_suffix`` can be
+        passed at the end to control whether ``VAR.suffix`` is appended to each
+        destination file. ``append_suffix`` defaults to ``True`` if not given,
+        and is only applicable when at least one ``file`` is passed.
 ``desc(OPTS, [type[, prolog[, epilog]]])``
         A simple function to customize ``OPTS['description']``. It can add an
         optional ``type`` of package (will append `` (<type>)`` to the first
@@ -827,6 +831,7 @@ For convenience, here is a simple example:
 
         ARGS = FUN.mapfiles(VAR.bindir, '/usr/bin', bins)
         ARGS += FUN.mapfiles('.', '/etc', 'util.conf', append_suffix=False)
+        ARGS += FUN.mapfiles('doc', '/usr/share/doc')
 
 Suppose that the targets ``daemon`` and ``client`` build the binaries
 ``daemon``, ``admtool``, ``util1`` and ``client``, ``clitool`` respectively,

--- a/mkpkg
+++ b/mkpkg
@@ -159,11 +159,19 @@ class Functions:
         return sorted(deps)
 
     def mapfiles(self, src, dst, *bins, **kwargs):
-        append_suffix = kwargs.get('append_suffix', True)
-        suffix = self.pkg.vars['suffix'] if append_suffix else ''
-        return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
-                src=src, dst=dst, bin=b, suffix=suffix)
-                    for b in self._expand_list(bins)])
+        if bins:
+            append_suffix = kwargs.get('append_suffix', True)
+            suffix = self.pkg.vars['suffix'] if append_suffix else ''
+            result = sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
+                        src=src, dst=dst, bin=b, suffix=suffix)
+                            for b in self._expand_list(bins)])
+        else:
+            if not src.endswith('/'):
+                src += '/'
+            if not dst.endswith('/'):
+                dst += '/'
+            result = ['{src}={dst}'.format(src=src, dst=dst)]
+        return result
 
     def mapbins(self, src, dst, *bins):
         warnf("'FUN.mapbins()' is deprecated, please use 'FUN.mapfiles()' instead")


### PR DESCRIPTION
Currently, 'FUN.mapfiles()' returns an empty list on attempting to
simply map directories (i.e. with no file names passed into the
function). Fix this so that the function returns a simple mapping from
the given source directory to the given destination directory if no file
names are passed.

I'm targeting `v1.9.x` as I consider this a bugfix rather than a new feature. There is also no release notes update for the same reason.