### PR TITLE
Add new 'example' target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,6 +270,8 @@ whole set of predefined targets are:
 * ``allunittest``
 * ``fastunittest``
 * ``integrationtest``
+* ``example``
+* ``example-run``
 * ``doc``
 * ``pkg``
 * ``graph-deps``
@@ -289,6 +291,12 @@ The ``fasttest`` target will only run the ``fastunittest`` target by default,
 but you can add more too by using the ``fasttest`` special variable.
 
 See the Testing_ section for more details.
+
+The ``example`` target will compile every ``.d`` file found under the
+``example/`` directory. The ``example-run`` target will compile and run
+all the found examples. An example can be skipped by adding the file to the
+``$(EXAMPLE_FILTER_OUT)`` variable. Check `Skipping tests`_ section for a
+similar example of filtering out files.
 
 The ``pkg`` target builds all packages defined in ``$P``, see Packaging_
 section for more details.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 New Features
 ============
 
+* `make example example-run`
+
+  Added new make targets 'example' and 'example-run'. The make targets will search for an `example/` directory in the root dir of the project. Each `*.d` file found will be compiled and copied into `build/last/bin/example/` directory. If `make example-run` is used, then the programs will be executed as well.
+
 * `VAR.fullname` `VAR.shortname`
 
   Added new variables, available in package definition files. `VAR.fullname` replaces the old `VAR.name` to make it more explicit, `VAR.shortname` contains only the package name, without the `VAR.suffix`.


### PR DESCRIPTION
I didn't find a tag for branch v2.x.x, so I wasn't sure if it was officially released yet. I've made the PR against v1.x.x. for now.

This PR adds new targets: `make examples` and `make examples-run`. The motivation is the following
1. Unit-tests are usually very focused on testing one specific aspect rather than giving a usage example.
2. Usage examples in documentation can get outdated and wouldn't be noticed.
3. At many times it's not convenient to browse the implementation code and understand the usage, especially that class implementations use inheritance and are spread over multiple modules.

So what this PR does is that it adds `make examples`. When executed, make will search for  `examples/` directory in the project root dir. The directory should contain  'real-life' examples of how code usage. CI tools can even optionally check whether example still compiles with each new PR.

If the general idea is accepted, then there are few small things to agree on:
1. Whether `examples` is a good target name or something else should be used (e.g `make samples`).
2. The `examples/` directory can contain non-`*.d` files (e.g config files). Should these be copied along to the output directory?
3. Should `test` target include `examples` target as well or should it be left to the user?