### PR TITLE
Small bug fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ also supported (see under `D2 support`_ for details).
 Versioning
 ----------
 
-MakD complies with `Netptune <https://github.com/sociomantic-tsunami/neptune>`_
+MakD complies with `Neptune <https://github.com/sociomantic-tsunami/neptune>`_
 for versioning.
 
 Support Guarantees

--- a/mkpkg
+++ b/mkpkg
@@ -158,12 +158,12 @@ class Functions:
                 continue
         return sorted(deps)
 
-    def mapfiles(self, src, dst, *bins, **kwargs):
+    def mapfiles(self, src, dst, *files, **kwargs):
         append_suffix = kwargs.get('append_suffix', True)
         suffix = self.pkg.vars['suffix'] if append_suffix else ''
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=suffix)
-                    for b in self._expand_list(bins)])
+                    for b in self._expand_list(files)])
 
     def mapbins(self, src, dst, *bins):
         warnf("'FUN.mapbins()' is deprecated, please use 'FUN.mapfiles()' instead")

--- a/mkpkg
+++ b/mkpkg
@@ -161,6 +161,10 @@ class Functions:
     def mapfiles(self, src, dst, *files, **kwargs):
         append_suffix = kwargs.get('append_suffix', True)
         suffix = self.pkg.vars['suffix'] if append_suffix else ''
+
+        src = src.rstrip('/')
+        dst = dst.rstrip('/')
+
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=suffix)
                     for b in self._expand_list(files)])


### PR DESCRIPTION
This is an alternative to #69. It disallows `FUN.mapfiles()` from being called without any files.