### PR TITLE
Move all unittest processing to the unittest target

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -51,13 +51,7 @@ PKG := $T/pkg
 -include $T/Config.local.mak
 
 # Directory where all the integration tests are
-ifndef INTEGRATIONTEST
-__dummy_integrationtest_warning := $(shell echo "MakD Warning: The default \
-	location of integration tests (defined by \$$(INTEGRATIONTEST) and 'test' \
-	by default now) will change to 'integrationtest' in v2.0.0. If you want to \
-	avoid this warning, please define it explicitly in your Config.mak." >&2)
-endif
-INTEGRATIONTEST ?= test
+INTEGRATIONTEST ?= integrationtest
 
 # Check flavours
 FLAVOR_IS_VALID_ := $(if $(filter $F,$(VALID_FLAVORS)),1,0)

--- a/README.rst
+++ b/README.rst
@@ -860,10 +860,6 @@ when you use the corresponding ``test`` and ``fasttest`` targets.
 
 Automatic *unittest* and integration tests support is added on top of that.
 
-All the tests are built using these extra options::
-
-        -unittest -debug=UnitTest -version=UnitTest
-
 If you have a test script, you can easily add the target to run that script to
 ``$(test)`` too (or ``$(fasttest))`` and ``$(test)`` if it's really fast).
 For example:
@@ -882,8 +878,13 @@ Unit tests
 ~~~~~~~~~~
 
 Only *unittest* that live in the directory specified by the ``$(SRC)`` variable
-are built and run automatically, the ``unittest`` target will scan for all the
-files with the ``.d`` suffix there.
+and the ``test`` directory (`Integration tests`_) are built and run
+automatically, the ``unittest`` target will scan for all the files with the
+``.d`` suffix there.
+
+All the unit tests are built using these extra options::
+
+        -unittest -debug=UnitTest -version=UnitTest
 
 There are two different categories of *unittest* though: fast and slow. Tests
 are assumed to be fast unless they are separated to a different file, with the
@@ -914,9 +915,22 @@ into the file generated to run the unit tests (importing all modules), you can
 define ``TEST_RUNNER_MODULE`` as an empty variable and then put the contents
 you want to add to the file in the ``TEST_RUNNER_STRING`` variable.
 
+Bear in mind that unless you exclude files with a ``main()`` function (see
+`Skipping tests`_), you'll get link errors about having multiple definitions
+for ``main()``. To avoid this issue you should ``version`` out all the
+``main()`` functions in your project (both to produce project binaries or to
+produce `Integration tests`_):
+
+.. code:: D
+
+        version (UnitTest) {} else
+        void main()
+        {
+            // stuff
+        }
+
 Integration tests
 ~~~~~~~~~~~~~~~~~
-
 
 Integration tests are expected to live in the ``$(INTEGRATIONTEST)`` directory
 (``test`` by default), and it is expected that each subdirectory there is

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,3 +38,27 @@ Migration Instructions
   ``OPTS``.
 
   Change ``FUN.desc(OPTS, ...)`` to ``FUN.desc(...)``.
+
+* The `integrationtest` target is not compiled using `-unittest -debug=UnitTest
+  -version=UnitTest` anymore as it complicates debugging and it wastes resources
+  (as not only the unit tests for those programs will be run but also all the
+  test for the library code will be run too).
+
+  Unit tests for the integrations tests are still run but now by the `unittest`
+  and `fastunittest` targets instead of `integrationtest`.
+
+* `main.d` files in `$(SRC)` will no longer be automatically added to
+  `TEST_FILTER_OUT` and it's not recommended to add them back manually either.
+   It is recommended to conditionally compile the `main()` function only when
+   not unit-testing instead:
+
+   ```d
+    version (UnitTest) {} else
+    void main()
+    {
+        // stuff
+    }
+    ```
+
+    This applies too to the integration tests `main.d` files.
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,9 @@ Migration Instructions
   Unit tests for the integrations tests are still run but now by the `unittest`
   and `fastunittest` targets instead of `integrationtest`.
 
+* Integration tests default location changed from `test` to `integrationtest`.
+  The location can be set explicitly via the variable ``INTEGRATIONTEST``.
+
 * `main.d` files in `$(SRC)` will no longer be automatically added to
   `TEST_FILTER_OUT` and it's not recommended to add them back manually either.
    It is recommended to conditionally compile the `main()` function only when


### PR DESCRIPTION
This commit moves the compilation and running of unittests to the
`unittest` target(s) and remove the flags `-unittest -debug=UnitTest
-version=UnitTest` when building integrationtests.

Fixes #41.