### PR TITLE
mkpkg: Die if no files are passed to mapfiles

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@ Migration Instructions
 * The deprecated packaging function `FUN.mapbins()` was removed, use
   `FUN.mapfiles()` instead.
 
+* `FUN.mapfiles()` could previously be called with only the source and
+  destination directories (i.e. without any files). Passing at least one file to
+  the function is now mandatory.
+
 * The deprecated packaging variable `VAR.name` was removed, use `VAR.fullname`
   instead.
 

--- a/mkpkg
+++ b/mkpkg
@@ -159,6 +159,8 @@ class Functions:
         return sorted(deps)
 
     def mapfiles(self, src, dst, *bins, **kwargs):
+        if not bins:
+            die("'FUN.mapfiles()' expects at least one file to be passed")
         append_suffix = kwargs.get('append_suffix', True)
         suffix = self.pkg.vars['suffix'] if append_suffix else ''
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(


### PR DESCRIPTION
Allowing no files to be passed results in 'mapfiles()' returning an empty list.