### PR TITLE
Merge branch 'v1.x.x' into v2.x.x

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -36,9 +36,6 @@ F ?= devel
 # use "." for the current directory)
 SRC = src
 
-# Directory where all the integration tests are
-INTEGRATIONTEST ?= test
-
 # Directory were this makefile is located (this must be done BEFORE including
 # any other Makefile)
 MAKD_PATH := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
@@ -52,6 +49,15 @@ PKG := $T/pkg
 
 # Load top-level directory local configuration
 -include $T/Config.local.mak
+
+# Directory where all the integration tests are
+ifndef INTEGRATIONTEST
+__dummy_integrationtest_warning := $(shell echo "MakD Warning: The default \
+	location of integration tests (defined by \$$(INTEGRATIONTEST) and 'test' \
+	by default now) will change to 'integrationtest' in v2.0.0. If you want to \
+	avoid this warning, please define it explicitly in your Config.mak." >&2)
+endif
+INTEGRATIONTEST ?= test
 
 # Check flavours
 FLAVOR_IS_VALID_ := $(if $(filter $F,$(VALID_FLAVORS)),1,0)

--- a/Makd.mak
+++ b/Makd.mak
@@ -36,6 +36,9 @@ F ?= devel
 # use "." for the current directory)
 SRC = src
 
+# Directory where all the integration tests are
+INTEGRATIONTEST ?= test
+
 # Directory were this makefile is located (this must be done BEFORE including
 # any other Makefile)
 MAKD_PATH := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
@@ -540,16 +543,18 @@ $O/%unittests.stamp: $O/%unittests
 ##########################
 
 # Integration tests are assumed to be standalone programs, so we just search
-# for files test/%/main.d and assume they are the entry point of the program
-# (and each subdirectory in test/ is a separate program).
+# for files $(INTEGRATIONTEST)/%/main.d and assume they are the entry point of
+# the program (and each subdirectory in $(INTEGRATIONTEST)/ is a separate
+# program).
 # The sources list is filtered through the $(TEST_FILTER_OUT) variable contents
 # (using the Make function $(filter-out)), so you can exclude an integration
 # test by adding the location of the main.d (as an absolute path using $C) by
 # adding it to this variable.
 # The target integrationtest builds and runs all the integration tests.
 .PHONY: integrationtest
-integrationtest: $(patsubst $T/test/%/main.d,$O/test-%.stamp,\
-		$(filter-out $(TEST_FILTER_OUT),$(wildcard $T/test/*/main.d)))
+integrationtest: $(patsubst $T/$(INTEGRATIONTEST)/%/main.d,$O/test-%.stamp,\
+		$(filter-out $(TEST_FILTER_OUT),\
+		$(wildcard $T/$(INTEGRATIONTEST)/*/main.d)))
 
 # Add integrationtest to the test general target
 test += integrationtest
@@ -557,7 +562,7 @@ test += integrationtest
 # General rule to build integration tests programs, this is the same as
 # building any other binary but including unittests too.
 $O/test-%: BUILD.d.depfile = $O/test-$*.mak
-$O/test-%: $T/test/%/main.d $G/build-d-flags
+$O/test-%: $T/$(INTEGRATIONTEST)/%/main.d $G/build-d-flags
 	$(call build_d,-unittest -debug=UnitTest -version=UnitTest)
 
 # General rule to Run the test suite binaries

--- a/Makd.mak
+++ b/Makd.mak
@@ -34,7 +34,7 @@ F ?= devel
 
 # Directory where all the source files are expected (must be a relative paths,
 # use "." for the current directory)
-SRC = src
+SRC ?= src
 
 # Directory were this makefile is located (this must be done BEFORE including
 # any other Makefile)

--- a/README.rst
+++ b/README.rst
@@ -710,7 +710,7 @@ variable ``FUN``:
                 FUN.desc(OPTS, prolog='A prolog',
                     epilog='And an epilog, but no type')
 
-        Note that ``OPTS['desciption']`` must be defined and hold a non-empty
+        Note that ``OPTS['description']`` must be defined and hold a non-empty
         string.
 
 Generated packages will be stored in the ``$P`` directory (by default

--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,8 @@ Variables you might want to override
 * ``TEST_RUNNER_MODULE`` and ``TEST_RUNNER_STRING`` are used to override the
   module or string to inject in the unittest file that runs all the unit tests.
   See Testing_ for details.
+* ``INTEGRATIONTEST`` to change the default location of integration tests
+  (``test`` by default).
 * ``SRC`` is where all the source files of your project is expected to be. By
   default is ``src`` but you can override it with ``.`` if you keep the source
   file in the top-level. The path must be relative to the project's top-level
@@ -908,10 +910,11 @@ you want to add to the file in the ``TEST_RUNNER_STRING`` variable.
 Integration tests
 ~~~~~~~~~~~~~~~~~
 
-Integration tests are expected to live in the ``test/`` directory, and it is
-expected that each subdirectory there is a separate test program, with
-a ``main.d`` file as the entry point. So the typical layout for the ``test/``
-directory is::
+
+Integration tests are expected to live in the ``$(INTEGRATIONTEST)`` directory
+(``test`` by default), and it is expected that each subdirectory there is
+a separate test program, with a ``main.d`` file as the entry point. So the
+typical layout for the ``$(INTEGRATIONTEST)/`` directory is::
 
         test/
              test_1/
@@ -922,7 +925,8 @@ directory is::
                     othermodule.d
 
 The ``integrationtest`` target scan for those individual programs (specifically
-for files with the pattern: ``test/*/main.d``) and builds them and runs them.
+for files with the pattern: ``$(INTEGRATIONTEST)/*/main.d``) and builds them
+and runs them.
 
 It is also expected that the integration tests are slow, so by default they are
 only added to the ``test`` target, but you can manually add them (all or just

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ also supported (see under `D2 support`_ for details).
 Versioning
 ----------
 
-MakD complies with `Netptune <https://github.com/sociomantic-tsunami/neptune>`_
+MakD complies with `Neptune <https://github.com/sociomantic-tsunami/neptune>`_
 for versioning.
 
 Support Guarantees

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,4 +25,6 @@ Deprecations
 * The `versionInfo` AA containing all the automatically deduced version
   information is deprecated, please use `version_info` instead.
 
+* The default location for integration tests (now defined by ``$(INTEGRATIONTEST)``, will change from `test` to `integrationtest` (see #74). To avoid warnings you can preempively define the variable explicitly (in which case we recommend to start using the new default location instead of the old one: `INTEGRATIONTEST := integrationtest` in `Config.mak`).
+
 Milestone: https://github.com/sociomantic-tsunami/makd/milestone/20?closed=1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,4 +20,7 @@ Deprecations
 
 * `FUN.mapbins()` is deprecated, please use `FUN.mapfiles()` instead.
 
+* The `versionInfo` AA containing all the automatically deduced version
+  information is deprecated, please use `version_info` instead.
+
 Milestone: https://github.com/sociomantic-tsunami/makd/milestone/20?closed=1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,8 @@ New Features
 
   A simple function to ease specifying files to include in the package (with the ability to control whether `VAR.suffix` is appended to each destination file using the named argument `append_suffix`).
 
+* Now the location of integrationtest is configurable through the ``INTEGRATIONTEST`` Make variable.
+
 Deprecations
 ============
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,22 +3,15 @@ New Features
 
 * `VAR.fullname` `VAR.shortname`
 
-  Added new variables, available in package definition files. `VAR.fullname`
-  replaces the old `VAR.name` to make it more explicit, `VAR.shortname` contains
-  only the package name, without the `VAR.suffix`.
+  Added new variables, available in package definition files. `VAR.fullname` replaces the old `VAR.name` to make it more explicit, `VAR.shortname` contains only the package name, without the `VAR.suffix`.
 
 * `FUN.desc()`
 
-  A simple function to customize `OPTS['description']`. It can add an optional
-  `type` of package (will append ` (<type>)` to the first line (short
-  description), `prolog` (inserted before the long description) and an `epilog`
-  (appended at the end of the long description.
+  A simple function to customize `OPTS['description']`. It can add an optional `type` of package (will append ` (<type>)` to the first line (short description), `prolog` (inserted before the long description) and an `epilog` (appended at the end of the long description.
 
 * `FUN.mapfiles()`
 
-  A simple function to ease specifying files to include in the package (with the
-  ability to control whether `VAR.suffix` is appended to each destination file
-  using the named argument `append_suffix`).
+  A simple function to ease specifying files to include in the package (with the ability to control whether `VAR.suffix` is appended to each destination file using the named argument `append_suffix`).
 
 Deprecations
 ============
@@ -26,3 +19,5 @@ Deprecations
 * `VAR.name` is deprecated, please use `VAR.fullname` instead.
 
 * `FUN.mapbins()` is deprecated, please use `FUN.mapfiles()` instead.
+
+Milestone: https://github.com/sociomantic-tsunami/makd/milestone/20?closed=1

--- a/Version.d.tpl
+++ b/Version.d.tpl
@@ -32,16 +32,20 @@ else
     alias char[] _tpl_istring;
 }
 
-_tpl_istring[_tpl_istring] versionInfo;
-deprecated("Please use @MODULE@.versionInfo instead (part of the D2 transition)")
-alias versionInfo Version;
+_tpl_istring[_tpl_istring] version_info;
+
+deprecated("@MODULE@.versionInfo is deprecated. Please rename it to version_info")
+alias version_info versionInfo;
+
+deprecated("Please use @MODULE@.version_info instead (part of the D2 transition)")
+alias version_info Version;
 
 static this()
 {
-    versionInfo["version"] = "@VERSION@";
-    versionInfo["build_date"] = "@DATE@";
-    versionInfo["build_author"] = "@AUTHOR@";
-    versionInfo["compiler"] = "@COMPILER@";
+    version_info["version"] = "@VERSION@";
+    version_info["build_date"] = "@DATE@";
+    version_info["build_author"] = "@AUTHOR@";
+    version_info["compiler"] = "@COMPILER@";
 @LIBRARIES@
     buildPredefinedVersions();
 }
@@ -117,12 +121,12 @@ private template Id (_tpl_istring name)
 {
     version (D_Version2)
     {
-        mixin("static immutable Id = `version (` ~ name ~ `) versionInfo[\"ver_`
+        mixin("static immutable Id = `version (` ~ name ~ `) version_info[\"ver_`
              ~ name ~ `\"] = \"` ~ name ~ `\";`;");
     }
     else
     {
-        const _tpl_istring Id = `version (` ~ name ~ `) versionInfo["ver_` ~ name ~
+        const _tpl_istring Id = `version (` ~ name ~ `) version_info["ver_` ~ name ~
             `"] = "` ~ name ~ `";`;
     }
 }

--- a/mkpkg
+++ b/mkpkg
@@ -158,12 +158,12 @@ class Functions:
                 continue
         return sorted(deps)
 
-    def mapfiles(self, src, dst, *bins, **kwargs):
+    def mapfiles(self, src, dst, *files, **kwargs):
         append_suffix = kwargs.get('append_suffix', True)
         suffix = self.pkg.vars['suffix'] if append_suffix else ''
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=suffix)
-                    for b in self._expand_list(bins)])
+                    for b in self._expand_list(files)])
 
     def mapbins(self, src, dst, *bins):
         warnf("'FUN.mapbins()' is deprecated, please use 'FUN.mapfiles()' instead")

--- a/mkpkg
+++ b/mkpkg
@@ -161,6 +161,10 @@ class Functions:
     def mapfiles(self, src, dst, *files, **kwargs):
         append_suffix = kwargs.get('append_suffix', True)
         suffix = self.pkg.vars['suffix'] if append_suffix else ''
+
+        src = src.rstrip('/')
+        dst = dst.rstrip('/')
+
         return sorted(['{src}/{bin}={dst}/{bin}{suffix}'.format(
                 src=src, dst=dst, bin=b, suffix=suffix)
                     for b in self._expand_list(files)])

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -101,7 +101,7 @@ do
     echo "$ver_desc" | egrep -q '^[0-9a-f]{7}(-dirty)?$'  &&
         ver_desc=`cd $lib && git rev-parse --abbrev-ref HEAD`-g"$ver_desc"
 
-    libs="${libs}    versionInfo[\"lib_${lib_base}\"] = \"${ver_desc}\";\\n"
+    libs="${libs}    version_info[\"lib_${lib_base}\"] = \"${ver_desc}\";\\n"
 done
 sed -i "s/@LIBRARIES@/$libs/" "$tmp"
 


### PR DESCRIPTION
This commit also removes the versionInfo symbol to complete the Version
and versionInfo symbol deprecation.

* v1.x.x:
  Add a warning when using "test" for integration tests
  Make the location of integration tests configurable
  Make $(SRC) overrideable
  mkpkg: Remove trailing '/' from src & dst
  mkpkg: Rename parameter of mapfiles to files
  README: Fix typo
  Rename versionInfo to version_info
  Fix typo in README
  Clear RELEASE_NOTES.md