### PR TITLE
pkg: Add ability to use options without values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -642,10 +642,12 @@ These files are expected to be Python scripts defining two variables:
         a fpm_ command-line option. If the key is only one character (for
         example ``c``), it will be passed as ``-<key><value>`` and if it's
         more, it will be passed as ``--<key>=<value>`` (``_`` characters in the
-        key will be replaced by ``-`` for convenience). The ``<value>`` can be a
-        string or an array of strings. In the latter case, the key is used as fpm_
-        flag for each item in ``<value>``. No validation is performed over the
-        keys or values, they are just passed blindly to fpm_.
+        key will be replaced by ``-`` for convenience). The ``<value>`` can be
+        ``True``, a string or an array of strings. If it's ``True``, just
+        ``-<key>`` or ``--<key>`` is passed (without an actual value), if it's
+        an array of strings, the key is used as fpm_ flag for each item in
+        ``<value>``. No validation is performed over the keys or values, they
+        are just passed blindly to fpm_.
 
 ``ARGS``
         a ``list()`` (array) to pass to fpm_ as positional arguments (usually the

--- a/mkpkg
+++ b/mkpkg
@@ -209,6 +209,12 @@ class Package:
         args = []
         for k, v in self.options.items():
             k = k.replace('_', '-')
+            if v is True:
+                if len(k) == 1:
+                    args.append('-'+k)
+                else:
+                    args.append('--'+k)
+                continue
             if len(k) == 1:
                 fmt = '-{}{}'
             else:


### PR DESCRIPTION
When an option has `True` as value, `mkpkg` will just pass `--key` (or
`-k`) to `fpm`, without any actual value. This allows using `fpm`
flags that don't take any value (on/off switches).