### PR TITLE
test: Add exception for importing x.y.package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -537,6 +537,23 @@ with a lazy variable:
         	$(check_dstep)
         	rdmd --build --whatever.
 
+file2module
+~~~~~~~~~~~
+This function converts a file path to a D module. It takes as first argument
+a file path to convert and as optional second argument the base path of the
+sources (path that is not part of the fully qualified module name), by defaul
+``$C/$(SRC)``. This function takes into account the special ``pkg/package.d``
+module name in D2, converting it to just ``pkg``.
+
+For example:
+
+.. code:: make
+
+        $(call file2module,project/x.d,project/) # -> x
+        $(call file2module,project/y/package.d,project/) # -> y
+        $(call file2module,./some/longer/pkg/package.d,./) # -> some.longer.pkg
+        $(call file2module,./some/longer/pkg/mod.d,./) # -> some.longer.pkg.mod
+
 V
 ~~~
 OK, this is not really a function, but you might use it in a way that can be

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,10 @@ New Features
 
   The location of the `d1to2fix` binary can now be overriden via the ``D1TO2FIX`` variable and the directories where the tool will look for source files too, via the `D1TO2FIX_DIRS` variable.
 
+* `file2module`
+
+  This new MakD function converts a file path to a D module. It takes as first argument a file path to convert and as optional second argument the base path of the sources (path that is not part of the fully qualified module name), by defaul `$C/$(SRC)`. This function takes into account the special `pkg/package.d` module name in D2, converting it to just `pkg`.
+
 Deprecations
 ============
 


### PR DESCRIPTION
When generating the `allunitests.d` file, for every file an `import` is
generated based on the file name, but in D2 the file `pkg/package.d` is
also allowed, but is imported when `pkg` is imported

Since using `package` as a file/import name is invalid in D1, is safe to
make this exception regardless of the D version being used.

Fixes #73.