### PR TITLE
Do not output colors for RDMD with DVER=2

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -298,20 +298,31 @@ abbr = $(if $(call eq,$(call abbr_helper,$1),$1),$1,$(addprefix \
 vexec_pc = $(if $1,\033[$1m%s\033[00m,%s)
 vexec_p = $(if $(COLOR), \
 	'   $(call vexec_pc,$(COLOR_CMD)) $(call vexec_pc,$(COLOR_ARG))\n$(if \
-			$(COLOR_OUT),\033[$(COLOR_OUT)m)', \
+			$1,\033[$1m)', \
 	'   %s %s\n')
 # Execute a command printing a nice message if $V is @.
 # $1 is mandatory and it's the command to execute.
 # $2 is the target name (defaults to $@).
 # $3 is the command name (defaults to the first word of $1).
-vexec = $(if $V,printf $(vexec_p) \
+# $4 should be empty to force non-colorized output
+vexec = $(if $V,printf $(call vexec_p,$4) \
 		'$(call abbr,$(if $3,$(strip $3),$(firstword $1)))' \
 		'$(call abbr,$(if $2,$(strip $2),$@))' ; )$1 \
-		$(if $(COLOR),$(if $(COLOR_OUT), ; r=$$? ; \
+		$(if $(COLOR),$(if $4, ; r=$$? ; \
 				printf '\033[00m' ; exit $$r))
 
 # Same as vexec but it silence the echo command (prepending a @ if $V).
-exec = $V$(call vexec,$1,$2,$3)
+# $1 is mandatory and it's the command to execute.
+# $2 is the target name (defaults to $@).
+# $3 is the command name (defaults to the first word of $1).
+exec = $V$(call vexec,$1,$2,$3,$(COLOR_OUT))
+
+# Same as exec but forcing non-colored output (useful for commands that are
+# already colorized)
+# $1 is mandatory and it's the command to execute.
+# $2 is the target name (defaults to $@).
+# $3 is the command name (defaults to the first word of $1).
+exec_nc = $V$(call vexec,$1,$2,$3)
 
 # Concatenate variables together.  The first argument is a list of variables
 # names to concatenate.  The second argument is an optional prefix for the

--- a/Makd.mak
+++ b/Makd.mak
@@ -403,7 +403,8 @@ check_deb = $Vi=`apt-cache policy $1 | grep Installed | cut -b14-`; \
 # 3: arguments to be passed to the $(POST_BUILD_D) script
 define build_d
 	$(PRE_BUILD_D) $2
-	$(call exec,$(BUILD.d) --build-only $1 $(LOADLIBES) $(LDLIBS) -of$@ \
+	$(call $(if $(subst 2,,$(DVER)),exec,exec_nc),\
+		$(BUILD.d) --build-only $1 $(LOADLIBES) $(LDLIBS) -of$@ \
 		$(firstword $(filter %.d,$^)))
 	$(POST_BUILD_D) $3
 endef

--- a/README.rst
+++ b/README.rst
@@ -481,6 +481,15 @@ This will print::
 When built. And will print ``touch -m touch-file`` if ``V=1`` is used, as
 expected.
 
+exec_nc
+~~~~~~~
+When ``COLOR`` is enabled, ``exec`` will colorize the output based on the
+``COLOR_OUT`` variable. For commands that use colors in the output themselves,
+having MakD coloring the output will just make the output weird. Because of
+this, there is this flavour of ``exec`` that will not colorize the output (but
+will still use colors, when enabled, for the fancy progress indication).
+
+
 build_d
 ~~~~~~~
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,8 @@ New Features
 
   There is a new MakD function to get fancy output but that doesn't force colors on the output of the commands that are being run. This is particularly useful for commands that already have colorized output.
 
+  This function is now used when invoking `dmd` when `DVER` is 2, so dmd colored output will work as expected.
+
 Deprecations
 ============
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,10 @@ New Features
 
 * Now the location of integrationtest is configurable through the ``INTEGRATIONTEST`` Make variable.
 
+* `exec_nc`
+
+  There is a new MakD function to get fancy output but that doesn't force colors on the output of the commands that are being run. This is particularly useful for commands that already have colorized output.
+
 Deprecations
 ============
 


### PR DESCRIPTION
DMD2 already does it, so by default the path will be in red, and the rest of the message with the right color.