### PR TITLE
Allow to specify which directories to convert for d2conv

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -131,6 +131,9 @@ HMOD ?= hmod
 # harbored-mod flags
 HMODFLAGS ?= --project-name $(PROJECT_NAME) --project-version $(VERSION)
 
+# Default d1to2fix binary location
+D1TO2FIX ?= d1to2fix
+
 # Default fpm binary location
 FPM ?= fpm
 
@@ -266,6 +269,9 @@ PKGVERSION := $(shell echo $(VERSION) | \
 # For more information refer to the documentation:
 # http://www.gnu.org/software/make/manual/make.html#Text-Functions
 TEST_FILTER_OUT := $C/$(SRC)/%/main.d
+
+# Directories to search for files to convert using d1to2fix
+D1TO2FIX_DIRS := $C
 
 
 # Functions
@@ -686,12 +692,12 @@ fasttest: $(fasttest)
 .PHONY: d2conv
 d2conv: $O/d2conv.stamp
 
-$O/d2conv.stamp: $C
-	$Vfind $C -type f -regex '^.+\.d$$' > $@
-ifeq "$(shell d1to2fix --help 2>/dev/null | grep -- --input)" ""
-	$(call exec, d1to2fix --fatal `cat $@`)
+$O/d2conv.stamp: $(D1TO2FIX_DIRS)
+	$Vfind $(D1TO2FIX_DIRS) -type f -regex '^.+\.d$$' > $@
+ifeq "$(shell $(D1TO2FIX) --help 2>/dev/null | grep -- --input)" ""
+	$(call exec, $(D1TO2FIX) --fatal `cat $@`)
 else
-	$(call exec, d1to2fix $(DIMPORTPATHS) --fatal --input=$@)
+	$(call exec, $(D1TO2FIX) $(DIMPORTPATHS) --fatal --input=$@)
 endif
 
 # Automatic dependency handling

--- a/README.rst
+++ b/README.rst
@@ -360,7 +360,8 @@ Variables you might want to override
 * ``P`` is where built packages will be created. Defaults to ``$G/pkg``.
 * Program location variables: ``DC`` is the D compiler to use, you can build
   your project with a different DMD by using ``make
-  DC=/usr/bin/experimental-dmd`` for example. Same for ``RDMD`` and ``FPM``.
+  DC=/usr/bin/experimental-dmd`` for example. Same for ``RDMD``, ``D1TO2FIX``
+  and ``FPM``.
 * ``D_GC`` to change the default (cdgc) GC implementation to use.
 * Less likely you might want to override the ``DFLAGS``, ``RDMDFLAGS`` or
   ``FPMFLAGS``, but usually there are better methods to do that instead.
@@ -371,6 +372,9 @@ Variables you might want to override
   See Testing_ for details.
 * ``INTEGRATIONTEST`` to change the default location of integration tests
   (``test`` by default).
+* ``D1TO2FIX_DIRS`` can be used to specify which directories to look for
+  D files to be converted to D2 via the ``d2conv`` target. By default ``$C`` is
+  used (i.e. the project's root).
 * ``SRC`` is where all the source files of your project is expected to be. By
   default is ``src`` but you can override it with ``.`` if you keep the source
   file in the top-level. The path must be relative to the project's top-level

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,10 @@ New Features
 
   This function is now used when invoking `dmd` when `DVER` is 2, so dmd colored output will work as expected.
 
+* `d2conv`
+
+  The location of the `d1to2fix` binary can now be overriden via the ``D1TO2FIX`` variable and the directories where the tool will look for source files too, via the `D1TO2FIX_DIRS` variable.
+
 Deprecations
 ============
 


### PR DESCRIPTION
Currently, the `d2conv` rule will perform a `find` on `$C`, that is, the top level directory of the git repo in most cases.
We have a use case where we have D2 scripts in the `scripts` folder, which get `d1to2fix`ed anyway, resulting in a diff (and possibly invalid code).

Having a mean to override which directory the `find` will be performed on should be enough to solve this problem.