### PR TITLE
INTEGRATIONTEST deprecation message appears when no test directory is present

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -52,10 +52,12 @@ PKG := $T/pkg
 
 # Directory where all the integration tests are
 ifndef INTEGRATIONTEST
+ifeq ($(if $(wildcard test/*/main.d),yes),yes)
 __dummy_integrationtest_warning := $(shell echo "MakD Warning: The default \
 	location of integration tests (defined by \$$(INTEGRATIONTEST) and 'test' \
 	by default now) will change to 'integrationtest' in v2.0.0. If you want to \
 	avoid this warning, please define it explicitly in your Config.mak." >&2)
+endif
 endif
 INTEGRATIONTEST ?= test
 


### PR DESCRIPTION
Makd v1.10.0 has deprecated using the `test` directory for integration tests, and introduces a new preferred default of `integrationtest`.  Projects that do not meet this new standard will receive a warning message:

```
MakD Warning: The default location of integration tests (defined by $(INTEGRATIONTEST) and 'test' by default now) will change to 'integrationtest' in v2.0.0. If you want to avoid this warning, please define it explicitly in your Config.mak.
```

However, this warning message appears even if there is no `test` directory (i.e. no integration tests at all).  This seems a bit counter-intuitive, since the only reason the warning is needed is if there are integration tests.

As a side note, it might be helpful if the deprecation message mentioned the other option of moving the `test` directory to `integrationtest` (since IIUC makd v1.10.0 already supports this as a preferred default, only falling back to `test` if `integrationtest` does not exist).
