### PR TITLE
[REG v2] Can't have integration tests with same module name

### DIFF
--- a/relnotes/default-integration.migration.md
+++ b/relnotes/default-integration.migration.md
@@ -1,3 +1,0 @@
-* Integration tests default location changed from `test` to `integrationtest`.
-
-  The location can be set explicitly via the variable `INTEGRATIONTEST`, but you are not required to define it anymore (as it was required in v1.x.x), you just need to define it if you don't want the new default (`integrationtest`).

--- a/relnotes/integrationtests.migration.md
+++ b/relnotes/integrationtests.migration.md
@@ -1,0 +1,15 @@
+* Unit and integration tests changes
+
+  * Starting with v2.0.0 Makd will compile all modules from integration tests as part of the regular unittest target and stop supplying the `-unittest` flag when compiling actual integration tests. This may break compilation of a project so some manual tweaks are required:
+
+    1. If integration test modules don't have module statements or multiple modules have the same name.
+
+       The solution is to add explicit module statements to give each file a distinct module name.
+
+    2. As with modules containing a `main()` in the regular user code in `$(SRC)`, integration test modules containing `main()` functions need to be modified to version out that `main()` function via `version(UnitTest)` (see the notes about changes to test and `main()` in general for more details about this), otherwise the unittest target will fail to link because of multiple `main()`s.
+
+       Again, you could manually add these modules to `TEST_FILTER_OUT`, but it is not recommended as any unit tests present in the module with the `main()` function won't be run this way.
+
+  * Integration tests default location changed from `test` to `integrationtest`
+
+    The location can be set explicitly via the variable `INTEGRATIONTEST`, but you are not required to define it anymore (as it was required in v1.x.x), you just need to define it if you don't want the new default (`integrationtest`). This change was introduced to avoid symbol clashes in D2 (if the root package is named `test` then no symbol named `test` can be used directly, and using the `test()` function in integration tests is very common).

--- a/relnotes/integrationtests.migration.md
+++ b/relnotes/integrationtests.migration.md
@@ -1,6 +1,6 @@
 * Unit and integration tests changes
 
-  * Starting with v2.0.0 Makd will compile all modules from integration tests as part of the regular unittest target and stop supplying the `-unittest` flag when compiling actual integration tests. This may break compilation of a project so some manual tweaks are required:
+  * Starting with v2.0.0 Makd will compile all modules from integration tests as part of the regular unittest target and stop supplying the `-unittest -version=UnitTest -debug=UnitTest` flags when compiling actual integration tests. This may break compilation of a project so some manual tweaks are required:
 
     1. If integration test modules don't have module statements or multiple modules have the same name.
 
@@ -9,6 +9,8 @@
     2. As with modules containing a `main()` in the regular user code in `$(SRC)`, integration test modules containing `main()` functions need to be modified to version out that `main()` function via `version(UnitTest)` (see the notes about changes to test and `main()` in general for more details about this), otherwise the unittest target will fail to link because of multiple `main()`s.
 
        Again, you could manually add these modules to `TEST_FILTER_OUT`, but it is not recommended as any unit tests present in the module with the `main()` function won't be run this way.
+
+    3. If you used `version(UnitTest)` or `debug(UnitTest)` blocks incorrectly (to `import` modules that are needed outside `unittest` too), you might get weird import errors.
 
   * Integration tests default location changed from `test` to `integrationtest`
 

--- a/relnotes/mkpkg-fun-desc.migration.md
+++ b/relnotes/mkpkg-fun-desc.migration.md
@@ -1,3 +1,0 @@
-* The `FUN.desc()` function for defining packages now doesn't take `OPTS` as an argument, it just gets the `OPTS['description']` from the built-in `OPTS`.
-
-  Change `FUN.desc(OPTS, ...)` to `FUN.desc(...)`.

--- a/relnotes/mkpkg-opts-args.migration.md
+++ b/relnotes/mkpkg-opts-args.migration.md
@@ -1,9 +1,0 @@
-* The `OPTS` and `ARGS` variables used when defining packages have become built-ins now, so they should be modified **in-place** (using `OPTS.update()`, `OPTS['xxx']`, and `ARGS.extend()`, `ARGS.append()` or any other functions that mutates the object).
-
-  You should **NEVER** re-bind (re-assign) these variables (`OPTS = ...`, `ARGS = ...` or even `ARGS += ...` and any other operators that re-assign the variable are forbidden).
-
-  Also, if you are using a `defaults.py` file, now just use `ìmport defaults` in `.pkg` files using it, don't explicitly import the `OPTS` and `ARGS` symbols anymore:
-
-  Change `from defaults import OPTS, ARGS` to `import defaults`.
-
-  This change helps making much compact utility functions. See changes on `FUN.desc()` for an example.

--- a/relnotes/pkg.migration.md
+++ b/relnotes/pkg.migration.md
@@ -1,0 +1,19 @@
+* Packaging
+
+  * The `OPTS` and `ARGS` variables used when defining packages have become built-ins now, so they should be modified **in-place** (using `OPTS.update()`, `OPTS['xxx']`, and `ARGS.extend()`, `ARGS.append()` or any other functions that mutates the object).
+
+    You should **NEVER** re-bind (re-assign) these variables (`OPTS = ...`, `ARGS = ...` or even `ARGS += ...` and any other operators that re-assign the variable are forbidden).
+
+    Also, if you are using a `defaults.py` file, now just use `ìmport defaults` in `.pkg` files using it, don't explicitly import the `OPTS` and `ARGS` symbols anymore:
+
+    Change `from defaults import OPTS, ARGS` to `import defaults`.
+
+    This change helps making much more compact utility functions. See changes on `FUN.desc()` for an example.
+
+  * The `FUN.desc()` function for defining packages now doesn't take `OPTS` as an argument, it just gets the `OPTS['description']` from the built-in `OPTS`.
+
+    Change `FUN.desc(OPTS, ...)` to `FUN.desc(...)`.
+
+  * The deprecated packaging function `FUN.mapbins()` was removed, use `FUN.mapfiles()` instead.
+
+  * The deprecated packaging variable `VAR.name` was removed, use `VAR.fullname` instead.

--- a/relnotes/rm-mapbins.migration.md
+++ b/relnotes/rm-mapbins.migration.md
@@ -1,1 +1,0 @@
-* The deprecated packaging function `FUN.mapbins()` was removed, use `FUN.mapfiles()` instead.

--- a/relnotes/rm-var-name.migration.md
+++ b/relnotes/rm-var-name.migration.md
@@ -1,1 +1,0 @@
-* The deprecated packaging variable `VAR.name` was removed, use `VAR.fullname` instead.


### PR DESCRIPTION
```
/docker/turtle/build/devel/tmp/allunittests.d(29): Error: module main from file test/dmqfull/main.d conflicts with another module main from file test/dhtrestart/main.d
```

I think this must be consequence of 145edfcd5b050736176a1d0c1436e8c47796cf34 - all those module are now built in one go and thus must have distinct module names (== explicit module statements in this turtle case).