### PR TITLE
Repeated `find` error messages for builds of projects with no integration tests

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -273,6 +273,12 @@ D1TO2FIX_DIRS := $C
 # returns empty.
 eq = $(if $(subst $1,,$2),,$1)
 
+# Simple wrapper to call find, only if the directory(ies) where to look exist
+# $1 find directories
+# $2 find options
+find = $(foreach d,$1,$(if $(shell test -d "$d" && echo true),\
+	   $(shell find $1 $2)))
+
 # Find files and get the their file names relative to another directory.
 # $1 is the files suffix (".h" or ".cpp" for example).
 # $2 is a directory rewrite, the matched files will be rewriten to
@@ -282,7 +288,7 @@ eq = $(if $(subst $1,,$2),,$1)
 # $4 is a `filter-out` pattern applied over the original file list (previous to
 #    the rewrite). It can be empty, which has no effect (nothing is filtered).
 find_files = $(patsubst $(if $3,$3,$C)/%$1,$(if $2,$2,$(if $3,$3,$C))/%$1, \
-		$(filter-out $4,$(shell find $(if $3,$3,$C) -name '*$1')))
+		$(filter-out $4,$(call find $(if $3,$3,$C),-name '*$1')))
 
 # Abbreviate a file name. Cut the leading part of a file if it match to the $T
 # directory, so it can be displayed as if it were a relative directory. Take
@@ -568,11 +574,12 @@ $O/%unittests: $O/%unittests.d $G/build-d-flags
 # use them to pass `-p pkg.` to the unit test runner.
 $O/%unittests.stamp: $O/%unittests
 	$(call exec,$< $(if $(findstring k,$(MAKEFLAGS)),-k) $(if $V,,-v -s) \
-		$(foreach p,$(shell find $C/$(SRC) -maxdepth 1 -mindepth 1 \
-					-name '*.d' -type f; \
-				find $C/$(SRC) -maxdepth 2 -mindepth 1 -wholename '*/package.d' \
-			),-p $(call file2module,$p)) \
-		$(foreach p,$(shell find $C/$(SRC) -maxdepth 1 -mindepth 1 -type d \
+		$(foreach p,$(call find $C/$(SRC),-maxdepth 1 -mindepth 1 \
+					-name '*.d' -type f) \
+				$(call find $C/$(SRC),-maxdepth 2 -mindepth 1 \
+					-wholename '*/package.d'), \
+			-p $(call file2module,$p)) \
+		$(foreach p,$(call find $C/$(SRC),-maxdepth 1 -mindepth 1 -type d \
 			),-p $(notdir $p).) \
 		 -p $(call file2module,$(INTEGRATIONTEST)). $(UTFLAGS),$<,run)
 	$Vtouch $@
@@ -649,7 +656,7 @@ $O/example-%.stamp: $O/example-%
 ######################
 
 # General rule to run the harbored-mod generator
-$O/doc.stamp: $(shell find $(SRC) -type f \( -name '*.d' -o -name '*.di' \))
+$O/doc.stamp: $(call find $(SRC),-type f \( -name '*.d' -o -name '*.di' \))
 	$(call exec,$(HMOD) -o $D $(HMODFLAGS) $(SRC) >/dev/null,doc)
 	$Vtouch $@
 
@@ -678,7 +685,7 @@ $O/depsfile: $O/allunittests.d
 # directory.
 setup_build_dir__ := $(shell \
 	mkdir -p $O $B $D $(GS) $P $(addprefix $O,$(patsubst $T%,%,\
-		$(shell find $T -type d $(foreach d,$(BUILD_DIR_EXCLUDE), \
+		$(call find $T,-type d $(foreach d,$(BUILD_DIR_EXCLUDE), \
 			-not -path '$T/$d' -not -path '$T/$d/*' \
 			-not -path '$T/*/$d' -not -path '$T/*/$d/*')))); \
 	rm -f $(VD)/last && ln -s $F $(VD)/last )
@@ -755,6 +762,6 @@ endif
 ################################
 
 # These files are created during compilation.
--include $(shell test -d $O && find $O -name '*.mak')
+-include $(call find $O,-name '*.mak')
 
 endif

--- a/README.rst
+++ b/README.rst
@@ -555,6 +555,19 @@ with a lazy variable:
         	$(check_dstep)
         	rdmd --build --whatever.
 
+find
+~~~~
+Wrapper around the ``find`` command to avoid errors when the directory to
+search doesn't exist at all. Use this to avoid spurious `find` errors.
+
+It takes the directory/ies where to search as first arguments and conditions and other `find` options as the second argument.
+
+Example:
+
+.. code:: make
+
+  files := $(call find $C/$(SRC),-name '*.di')
+
 find_files
 ~~~~~~~~~~
 Find files and get the their file names relative to another directory.

--- a/README.rst
+++ b/README.rst
@@ -555,6 +555,25 @@ with a lazy variable:
         	$(check_dstep)
         	rdmd --build --whatever.
 
+find_files
+~~~~~~~~~~
+Find files and get the their file names relative to another directory.
+
+Arguments are:
+
+1. The files suffix (``.h`` or ``.cpp`` for example).
+2. A directory rewrite, the matched files will be rewriten to be in the
+   directory specified in this argument (it defaults to ``$3`` if omitted).
+3. Where to search for the files (``$C`` if omitted).
+4. A ``filter-out`` pattern applied over the original file list (previous to
+   the rewrite). It can be empty, which has no effect (nothing is filtered).
+
+Example:
+
+.. code:: make
+
+  UNITTEST_FILES := $(call find_files,.d,,$C/$(SRC),$(TEST_FILTER_OUT))
+
 file2module
 ~~~~~~~~~~~
 This function converts a file path to a D module. It takes as first argument

--- a/relnotes/find.feature.md
+++ b/relnotes/find.feature.md
@@ -1,0 +1,1 @@
+* A new `find` function was added to MakD to avoid errors if the directory where to find the files doesn't exist. Use it instead of the `find` command to avoid spurious `find` errors.


### PR DESCRIPTION
When attempting to build a project without integration tests using v2.0.0-rc1, the following error message occurs multiple times in the build log:

```
find: ‘/home/me/projectdir/integrationtest’: No such file or directory
```

This does not happen for v1.x.x, and feels a bit intrusive, so it would be nice if `find` could fail silently in these cases.