### PR TITLE
Add coverage support

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -279,6 +279,22 @@ TEST_FILTER_OUT := $C/$(SRC)/%/main.d
 D1TO2FIX_DIRS := $C
 
 
+# Code coverage
+################
+
+# Set to 1 to compile with code coverage
+COV ?= 0
+
+# Configure environment for coverage
+ifeq ($(COV),1)
+override DFLAGS += -cov
+DRT_COVMERGE ?= 1
+export DRT_COVMERGE
+DRT_COVDSTPATH ?= $O/cov
+export DRT_COVDSTPATH
+endif
+
+
 # Functions
 ############
 
@@ -687,7 +703,7 @@ $O/depsfile: $O/allunittests.d
 # project into $O. Create one symbolic link "last" to the current build
 # directory.
 setup_build_dir__ := $(shell \
-	mkdir -p $O $B $D $(GS) $P $(addprefix $O,$(patsubst $T%,%,\
+	mkdir -p $O $O/cov $B $D $(GS) $P $(addprefix $O,$(patsubst $T%,%,\
 		$(shell find $T -type d $(foreach d,$(BUILD_DIR_EXCLUDE), \
 			-not -path '$T/$d' -not -path '$T/$d/*' \
 			-not -path '$T/*/$d' -not -path '$T/*/$d/*')))); \

--- a/README.rst
+++ b/README.rst
@@ -1101,3 +1101,15 @@ be re-compiled in that case!
 .. _Makeit: https://git.llucax.com/w/software/makeit.git
 .. _fpm: https://github.com/jordansissel/fpm
 
+
+Coverage
+--------
+
+Compiling using code coverage can be done by passing ``COV=1`` to ``make``. If
+the D compiler supports the ``DRT_COV*`` environment variables (dmd 1.081+ and
+2.077+), the coverage reports will be put in the ``$O/cov`` directory (it can
+be overridden by setting the ``DRT_COVDSTPATH`` directly), otherwise they will
+be written in the top-level directory.
+
+Also by default the the coverage reports will be merged. To change this you can
+override the ``DRT_COVMERGE`` environment variable directly.

--- a/relnotes/cov.feature.md
+++ b/relnotes/cov.feature.md
@@ -1,0 +1,4 @@
+* Coverage support
+
+  Now MakD will handle compiling and running with code coverage if `COV=1` is
+  used. This should be provided for both compiling and running tests.


### PR DESCRIPTION
When using `make COV=1` the code will be compiled with `-cov`, and will
generate coverage reports when running.