### PR TITLE
Add branch name to version string if possible

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -58,7 +58,7 @@ do
 done
 shift `expr $OPTIND - 1`
 
-version=`git describe --dirty --always`
+version=`git describe --dirty --always --abbrev=7`
 # Add branch name if we only got a hash
 echo "$version" | egrep -q '^[0-9a-f]{7}(-dirty)?$'  &&
     version=`git rev-parse --abbrev-ref HEAD`-g"$version"
@@ -96,7 +96,7 @@ for lib in "$@"
 do
     lib_base=`basename $lib`
 
-    ver_desc=`cd $lib && git describe --dirty --always`
+    ver_desc=`cd $lib && git describe --dirty --always --abbrev=7`
     # Add branch name if we only got a hash
     echo "$ver_desc" | egrep -q '^[0-9a-f]{7}(-dirty)?$'  &&
         ver_desc=`cd $lib && git rev-parse --abbrev-ref HEAD`-g"$ver_desc"

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -60,7 +60,7 @@ shift `expr $OPTIND - 1`
 
 version=`git describe --dirty --always --abbrev=7`
 # Add branch name if we only got a hash
-echo "$version" | egrep -q '^[0-9a-f]{7}(-dirty)?$'  &&
+echo "$version" | egrep -q '^.*[0-9a-f]{7}(-dirty)?$'  &&
     version=`git rev-parse --abbrev-ref HEAD`-g"$version"
 
 # Check if the user only wanted to print the version number
@@ -98,7 +98,7 @@ do
 
     ver_desc=`cd $lib && git describe --dirty --always --abbrev=7`
     # Add branch name if we only got a hash
-    echo "$ver_desc" | egrep -q '^[0-9a-f]{7}(-dirty)?$'  &&
+    echo "$ver_desc" | egrep -q '^.*[0-9a-f]{7}(-dirty)?$'  &&
         ver_desc=`cd $lib && git rev-parse --abbrev-ref HEAD`-g"$ver_desc"
 
     libs="${libs}    version_info[\"lib_${lib_base}\"] = \"${ver_desc}\";\\n"

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -60,7 +60,7 @@ shift `expr $OPTIND - 1`
 
 version=`git describe --dirty --always --abbrev=7`
 # Add branch name if we only got a hash
-echo "$version" | egrep -q '^.*[0-9a-f]{7}(-dirty)?$'  &&
+echo "$version" | grep -Eq '^.*[0-9a-f]{7}(-dirty)?$' &&
     version=`git rev-parse --abbrev-ref HEAD`-g"$version"
 
 # Check if the user only wanted to print the version number
@@ -98,7 +98,7 @@ do
 
     ver_desc=`cd $lib && git describe --dirty --always --abbrev=7`
     # Add branch name if we only got a hash
-    echo "$ver_desc" | egrep -q '^.*[0-9a-f]{7}(-dirty)?$'  &&
+    echo "$ver_desc" | grep -Eq '^.*[0-9a-f]{7}(-dirty)?$' &&
         ver_desc=`cd $lib && git rev-parse --abbrev-ref HEAD`-g"$ver_desc"
 
     libs="${libs}    version_info[\"lib_${lib_base}\"] = \"${ver_desc}\";\\n"


### PR DESCRIPTION
This was always meant to work, but never did reliably in practice. This should hopefully improve things without causing any differences to the version string when dealing with tagged commits.