### PR TITLE
 Allow to exclude some packages from building

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -151,6 +151,9 @@ PKGTYPE ?= deb
 # Default flags to pass to graph-deps (see --help for details)
 GRAPH_DEPS_FLAGS ?= -c -C
 
+# Packages files to build. Each file builds a different package.
+PKG_FILES ?= $(wildcard $(PKG)/*.pkg)
+
 # Default fpm flags. By default it builds Debian packages from files, a Debian
 # changelog is provided, and a version and iteration (using the Debian version)
 # (defined lazily so we can use target variables)
@@ -485,9 +488,6 @@ $B/%: $G/build-d-flags
 clean:
 	$(call exec,$(RM) -r $(VD) $(clean),$(VD) $(clean))
 
-# Phony target to build all packages
-.PHONY: pkg
-pkg: $(patsubst $(PKG)/%.pkg,$O/pkg-%.stamp,$(wildcard $(PKG)/*.pkg))
 
 # Target to build a package based on the fpm definition (old packages are
 # removed to avoid infinite pollution of the build directory, as every package
@@ -744,6 +744,11 @@ test: $(test)
 # to build and run tests to the $(fasttest) variable).
 .PHONY: fasttest
 fasttest: $(fasttest)
+
+# Phony rule to build all packages
+pkg += $(patsubst $(PKG)/%.pkg,$O/pkg-%.stamp,$(PKG_FILES))
+.PHONY: pkg
+pkg: $(pkg)
 
 
 # Temporary rule to convert code from D1 to D2

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ for versioning.
 Support Guarantees
 ------------------
 
-* Major branch development period: undefined
+* Major branch development period: 3 months
 * Maintained minor versions: 2 most recent
 
 Maintained Major Branches
@@ -34,9 +34,12 @@ Maintained Major Branches
 ====== ==================== ===============
 Major  Initial release date Supported until
 ====== ==================== ===============
-v1.x.x v1.4.0_: 24/06/2016  TBD
+v1.x.x v1.4.0_: 24/06/2016  Fri 08/12/2017
+====== ==================== ===============
+v2.x.x v2.0.0_: 08/09/2017  TBD
 ====== ==================== ===============
 .. _v1.4.0: https://github.com/sociomantic-tsunami/makd/releases/tag/v1.4.0
+.. _v2.0.0: https://github.com/sociomantic-tsunami/makd/releases/tag/v2.0.0
 
 
 .. contents::
@@ -1100,4 +1103,3 @@ be re-compiled in that case!
 
 .. _Makeit: https://git.llucax.com/w/software/makeit.git
 .. _fpm: https://github.com/jordansissel/fpm
-

--- a/README.rst
+++ b/README.rst
@@ -404,6 +404,7 @@ Variables you might want to override
 * ``PKG`` is where package definitions are searched. When building packages,
   each ``*.pkg`` file in that directory will be built. By default ``$T/pkg``.
 * ``PKG_DEFAULTS`` contains the default options passed to ``mkpkg``.
+* ``PKG_FILES`` contains the list of packages definitions.
 * ``PKG_PREBUILD`` hold commands to run previous to build packages.
 * ``PROJECT_NAME`` contains the name of the project, used in documentation
   generatation. It defaults to the name of the top directory.
@@ -683,9 +684,13 @@ Packaging
 
 Makd supports a simple facility to make packages based on fpm_.  A simple
 wrapper program ``mkpkg`` is provided to ease the creation of scripts that use
-fpm_ to create packages.  The predefined ``pkg`` target will scan for ``*.pkg``
-files in the ``$(PKG)`` directory (by default ``$T/pkg``) and then invoke
-``mkpkg`` with them.
+fpm_ to create packages.
+The predefined ``pkg`` target depends on the special variable ``$(pkg)``,
+where you can add any extra target that must be built for ``pkg``.
+By default every package file specified in `$(PKG_FILES)` will be
+added to ``$(pkg)``, and by default ``$(PKG_FILES)`` holds all
+``*.pkg`` files in the ``$(PKG)`` directory (by default ``$T/pkg``).
+``mkpkg`` is invoked for every file specified in ``$(PKG_FILES)``.
 
 These files are expected to be Python scripts defining two variables:
 
@@ -768,6 +773,15 @@ variable ``FUN``:
 
         Note that ``OPTS['description']`` must be defined and hold a non-empty
         string.
+
+One can exclude packages from being built under certain conditions
+(e.g. D1/D2 only packages) by filtering ``PKG_FILES``:
+
+.. code:: Makefile
+
+          ifeq ($(DVER),1)
+          PKG_FILES := $(filter-out $(PKG)/D2OnlyApp.pkg,$(PKG_FILES))
+          endif
 
 Generated packages will be stored in the ``$P`` directory (by default
 ``$G/pkg``. Since each package usually have a different name, as the version

--- a/relnotes/pkgs-variable.feature.md
+++ b/relnotes/pkgs-variable.feature.md
@@ -1,0 +1,11 @@
+* `PKG_FILES`
+
+  This variable holds all package definitions to be build. The purpose is to allow one to exclude
+  some packages from being built if need be, for example for `F=production` or `DVER=2`
+  only packages.
+  It can be filtered-out, e.g:
+  ```
+  ifeq ($(DVER),1)
+  PKG_FILES := $(filter-out $(PKG)/D2OnlyApp.pkg,$(PKG_FILES))
+  endif
+  ```


### PR DESCRIPTION
> Some users might have packages that can only be built in a certain configuration, e.g. a certain flavor, D1/D2 only...
> In order for account for those cases, one can filter-out the PKGS variable (or override it).

Also defines support term for major branch since we now have 2.