### PR TITLE
Fix for replacing `@DFLAGS@` with build flags

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -95,7 +95,7 @@ sed -i "$tmp" \
     -e "s/@DATE@/$date/" \
     -e "s/@AUTHOR@/$author/" \
     -e "s/@COMPILER@/$compiler/" \
-    -e "s/@DFLAGS@/$DFLAGS/" \
+    -e "s\#@DFLAGS@\#$DFLAGS\#" \
     -e "s/@FLAVOUR@/$F/"
 
 # Generate the libraries info


### PR DESCRIPTION
This change replaces the sed delimiter used for replacing the string
`@DFLAGS@` with the contents of `$DFLAGS` to use `\#` instead of `/`.
This is safer because `#` is unlikely to be in `$DFLAGS` whereas `/` is
part of most filesystem paths. An alternative is to escape any usage of
`/` in the contents of `$DFLAGS`.

Fixes sociomantic-tsunami/makd#111.