### PR TITLE
Add coverage support

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -264,6 +264,31 @@ TEST_FILTER_OUT :=
 D1TO2FIX_DIRS := $C
 
 
+# Code coverage
+################
+
+# Set to 1 to compile with code coverage
+COV ?= 0
+
+# Set where to put the coverage reports
+COVDIR ?= $O/cov
+
+# Set merging of coverage reports
+COVMERGE ?= 1
+
+# Configure environment for coverage
+ifeq ($(COV),1)
+    override DFLAGS += -cov
+    ifeq ($(DVER),1)
+        DRT_COVMERGE ?= $(COVMERGE)
+        export DRT_COVMERGE
+        DRT_COVDSTPATH ?= $(COVDIR)
+        export DRT_COVDSTPATH
+    else # DVER is 2
+		override _test_drt_opts := --DRT-covopt="merge:$(COVMERGE) dstpath:$(COVDIR)"
+    endif
+endif
+
 # Functions
 ############
 
@@ -476,6 +501,12 @@ $B/%: $G/build-d-flags
 clean:
 	$(call exec,$(RM) -r $(VD) $(clean),$(VD) $(clean))
 
+# Clean the coverage reports directory, useful to re-run and collect new stats
+.PHONY: clean-cov
+clean-cov:
+	$(call exec,$(RM) -r $(COVDIR))
+	$Vmkdir -p $(COVDIR)
+
 
 # Target to build a package based on the fpm definition (old packages are
 # removed to avoid infinite pollution of the build directory, as every package
@@ -577,7 +608,8 @@ $O/%unittests.stamp: $O/%unittests
 			-p $(call file2module,$p)) \
 		$(foreach p,$(call find,$C/$(SRC),-maxdepth 1 -mindepth 1 -type d \
 			),-p $(notdir $p).) \
-		 -p $(call file2module,$(INTEGRATIONTEST)). $(UTFLAGS),$<,run)
+		-p $(call file2module,$(INTEGRATIONTEST)). $(UTFLAGS) \
+		$(_test_drt_opts),$<,run)
 	$Vtouch $@
 
 # Integration tests rules
@@ -608,7 +640,7 @@ $O/test-%: $T/$(INTEGRATIONTEST)/%/main.d $G/build-d-flags
 
 # General rule to Run the test suite binaries
 $O/test-%.stamp: $O/test-%
-	$(call exec,$< $(ITFLAGS),$<,run)
+	$(call exec,$< $(_test_drt_opts) $(ITFLAGS),$<,run)
 	$Vtouch $@
 
 # Rule to build examples
@@ -680,7 +712,7 @@ $O/depsfile: $O/allunittests.d
 # project into $O. Create one symbolic link "last" to the current build
 # directory.
 setup_build_dir__ := $(shell \
-	mkdir -p $O $B $D $(GS) $P $(addprefix $O,$(patsubst $T%,%,\
+	mkdir -p $O $O/cov $B $D $(GS) $P $(addprefix $O,$(patsubst $T%,%,\
 		$(call find,$T,-type d $(foreach d,$(BUILD_DIR_EXCLUDE), \
 			-not -path '$T/$d' -not -path '$T/$d/*' \
 			-not -path '$T/*/$d' -not -path '$T/*/$d/*')))); \

--- a/README.rst
+++ b/README.rst
@@ -419,6 +419,9 @@ Variables you might want to override
   running the command to build D targets (when using the ``build_d`` function).
   By default they are used to generate the ``Version.d`` file, but users can
   override it not to generate the file or do something else on top of that.
+* ``COV`` will compile and run tests with coverage support if is set to ``1``. Please see Coverage_ for details.
+* ``COVDIR`` specifies the directory where to store coverage reports (by default ``$O/cov``. Please see Coverage_ for details.
+* ``COVMERGE`` indicates if coverage reports should be merged (``1`` will merge, ``0`` will not). Please see Coverage_ for details.
 
 Some of this variables are typically overridden in the Config.mak_ file, others
 in the Build.mak_ file, others in the Config.local.mak_ or directly in the
@@ -1170,3 +1173,31 @@ be re-compiled in that case!
 
 .. _Makeit: https://git.llucax.com/w/software/makeit.git
 .. _fpm: https://github.com/jordansissel/fpm
+
+
+Coverage
+--------
+
+Compiling using code coverage can be done by passing ``COV=1`` to ``make``. If
+the D runtime supports the ``DRT_COV*`` environment variables (see list of
+version below), the coverage reports will be put in the ``$(COVDIR)`` directory
+(``$O/cov`` by default), otherwise they will be written in the top-level
+directory.
+
+Also by default the the coverage reports will be merged. To change this you can
+override the ``$(COVMERGE)`` environment variable (``1`` to merge,
+``0`` to overwrite). This also only works for the versions specified
+below, previous versions will always overwrite the reports on each
+run.
+
+You should be **careful about report merging**, as unless you clean the reports
+manually, they will be accumulated ad infinitum as there is no obvious point
+where reports can be cleaned automatically (except for ``make clean`` of
+course). There is a convenience target to just clean coverage reports:
+``clean-cov``.
+
+Merging and overrideable dirirectory versions:
+
+* ``dmd1``: tangort v1.8.0+
+* ``dmd-transitional``: v2.070.2.s15+ and v2.071.2.s4+
+* ``dmd``: v2.078.0+

--- a/relnotes/cov.feature.md
+++ b/relnotes/cov.feature.md
@@ -1,0 +1,12 @@
+# Coverage support
+
+Now MakD will handle compiling and running with code coverage if `COV=1` is
+used. This should be provided for both compiling and running tests. Please
+refer to the documentation for more details.
+
+Full support in only provided by the following DMD runtime versions (merging
+coverage reports support is needed for this to work properly):
+
+* ``dmd1``: tangort v1.8.0+
+* ``dmd-transitional``: v2.070.2.s15+ and v2.071.2.s4+
+* ``dmd``: v2.078.0+


### PR DESCRIPTION
When using `make COV=1` the code will be compiled with `-cov`, and will
generate coverage reports when running.