### PR TITLE
Add support for specifying a custom package iteration

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -146,9 +146,13 @@ PKG_FILES ?= $(wildcard $(PKG)/*.pkg)
 # (defined lazily so we can use target variables)
 ifndef PKG_DEFAULTS
 DISTRO_CODENAME="$(shell lsb_release -rs | grep rolling || lsb_release -cs)"
+
+# Default package iteration
+PKGITERATION ?= "$(DISTRO_CODENAME)"
+
 PKG_DEFAULTS = -D-f -D-sdir -D-t$(PKGTYPE) -D--deb-changelog="$O/changelog.Debian" \
 		-D--version="$(PKGVERSION)" \
-		-D--iteration="$(DISTRO_CODENAME)" \
+		-D--iteration="$(PKGITERATION)" \
 		-d lsb_release="$(DISTRO_CODENAME)"
 endif
 
@@ -486,6 +490,7 @@ $O/pkg-%.stamp: $(PKG)/%.pkg $G/pkg-flags
 		$(if $V,,-vv) -D-p"$P" -F "$(FPM)" \
 		$(PKG_DEFAULTS) \
 		-d suffix="$(PKG_SUFFIX)" -d version="$(PKGVERSION)" \
+		-d iteration="$(PKGITERATION)" \
 		-d builddir="$G" -d bindir="$B" \
 		-d fullname="$*$(PKG_SUFFIX)" -d shortname="$*" \
 		$<,$<,mkpkg)

--- a/README.rst
+++ b/README.rst
@@ -415,6 +415,9 @@ Variables you might want to override
   obtained via the ``mkversion.sh`` by default.
 * ``PKGVERSION`` is the version to be used when creating packages. It's
   obtained via the ``VERSION`` variable by default.
+* ``PKGITERATION`` optionally allows setting the package *iteration* (forwarded
+  to `fpm` as `--iteration`, known as the `debian_revision`
+  [in Debian](https://www.debian.org/doc/debian-policy/#version)).
 * ``PRE_BUILD_D`` and ``POST_BUILD_D`` hold scripts executed before and after
   running the command to build D targets (when using the ``build_d`` function).
   By default they are used to generate the ``Version.d`` file, but users can
@@ -764,6 +767,9 @@ passed to the ``mkpkg`` util. By default Makd passes the following variables:
 
 ``version``
         package version number as defined by ``PKGVERSION``.
+
+``iteration``
+        package iteration as defined by ``PKGITERATION``.
 
 ``builddir``
         base build directory (``$G``).

--- a/relnotes/pkg-iteration.feature.md
+++ b/relnotes/pkg-iteration.feature.md
@@ -1,0 +1,25 @@
+## The package iteration can now be specified via `PKGITERATION`
+
+Package versions consist of two components: the _upstream version_, and
+the _package iteration_ (corresponding to the `debian_revision` where
+deb packages are concerned).
+
+Previously the package iteration was hardcoded to match the distro code
+(e.g. `xenial`), disallowing typical patterns referencing the packager
+and changes to the packaging rather than the upstream project.
+
+The new `PKGITERATION` variable allows the package iteration to be set
+to whatever is wanted, whether via `Config.mak` or the command line.
+It still defaults to the distro code, meaning nothing will change for
+existing package definitions, but can now be customized where this is
+appropriate (e.g. for packages of 3rd-party projects).
+
+Note that if you want to include the distro code in a customized package
+iteration, this will have to be included manually.  For example,
+`PKGITERATION=3~"$(lsb_release -cs)"` will produce iterations such as
+`3~trusty`, `3~xenial`, etc. depending on the distro used to build the
+package.
+
+For some examples of how to set the package iteration, see the
+ [Debian versioning policy](https://www.debian.org/doc/debian-policy/#version)
+and [the Ubuntu `debian_revision` schema](https://askubuntu.com/questions/620533/how-does-ubuntu-name-packages).


### PR DESCRIPTION
Package versioning includes at least two components:

  * the upstream package version (e.g. `1.0.3`)

  * the package iteration (e.g. `0ubuntu0`)

which for deb packages result in a package version like:

    1.0.3-0ubuntu0

Makd has until now hardcoded the assumption that the package iteration should be the same as the distro codename (`trusty`, `xenial`, etc.), but this is not typical practice in Debian packaging, where it is used instead to indicate detailed information on the version of the package (rather than the project being packaged); `0ubuntu0`, `1ubuntu3`, etc.

This patch adds a new, customizable `PKGITERATION` variable which can be set in build scripts or via the command line.  It defaults to the distro codename (meaning nothing will change if it is not explicitly set), but allows the user to override this default.