### PR TITLE
git-deblog: Fix multiple tags for one commit warning

### DIFF
--- a/git-deblog
+++ b/git-deblog
@@ -168,14 +168,14 @@ def get_tag(refs):
             tags.remove(t)
     if not tags:
         return None
-    if len(tags) > 1:
-        warn('more than one tag found for commit {}, using the first '
-                'one ({})', hash, ', '.join(tags))
     def get_field(field):
         hdr = field + ' '
         r = [l for l in tag_info if l.startswith(hdr)]
         return [l for l in tag_info if l.startswith(hdr)][0][len(hdr):]
     hash = get_field('object')
+    if len(tags) > 1:
+        warn('more than one tag found for commit {}, using the first '
+                'one ({})', hash, ', '.join(tags))
     author, timestamp, offset = get_field('tagger').rsplit(' ', 2)
     tz = timezone(timedelta(minutes=int(offset[0]+'1') * (
             int(offset[1:2])*60 + int(offset[3:4]))))

--- a/git-deblog
+++ b/git-deblog
@@ -157,7 +157,7 @@ def get_tag(refs):
     tag_re = re.compile(r'(?:^|, )tag: (?P<tag>.*?)(?:,|$)')
     tag = None
     tags = set(tag_re.findall(refs))
-    for t in set(tags):
+    for t in sorted(set(tags), reverse=True):
         try:
             ti = run('git cat-file tag'.split() + [t], stderr=PIPE)
             if tag is None:
@@ -174,8 +174,8 @@ def get_tag(refs):
         return [l for l in tag_info if l.startswith(hdr)][0][len(hdr):]
     hash = get_field('object')
     if len(tags) > 1:
-        warn('more than one tag found for commit {}, using the first '
-                'one ({})', hash, ', '.join(tags))
+        warn('more than one tag ({}) found for commit {}, using the last '
+                'one ({})', ', '.join(tags), hash, tag)
     author, timestamp, offset = get_field('tagger').rsplit(' ', 2)
     tz = timezone(timedelta(minutes=int(offset[0]+'1') * (
             int(offset[1:2])*60 + int(offset[3:4]))))


### PR DESCRIPTION
The warning needed a hash variable that was yet undefined.