### PR TITLE
Add build option to request position-independent code

### DIFF
--- a/Makd.mak
+++ b/Makd.mak
@@ -183,6 +183,14 @@ override DFLAGS += -O -inline
 endif
 
 
+# Position-independent code
+############################
+
+ifeq ($(USE_PIC),1)
+override DFLAGS += -fPIC
+endif
+
+
 # Directories
 ##############
 

--- a/relnotes/PIC.feature.md
+++ b/relnotes/PIC.feature.md
@@ -1,0 +1,7 @@
+### Position-independent code can now be specified with `USE_PIC`
+
+Newer distro releases (e.g. Ubuntu 18.04) require builds to use position
+independent code (i.e. the `-fPIC` build flag), otherwise linking fails.
+The new `USE_PIC` build variable can be used to enable this option:
+
+    USE_PIC=1 make [...]


### PR DESCRIPTION
Newer distro releases (e.g. Ubuntu 18.04) require builds to use position independent code (i.e. the `-fPIC` build flag), otherwise linking fails.  The new `USE_PIC` build variable can be used to enable this option:

    USE_PIC=1 make [...]