### PR TITLE
Remove invalid backslashes from Version.Id template string

### DIFF
--- a/Version.d.tpl
+++ b/Version.d.tpl
@@ -103,6 +103,6 @@ private void buildPredefinedVersions()
 
 private template Id (string name)
 {
-    static immutable Id = `version (` ~ name ~ `) version_info[\"ver_`
-         ~ name ~ `\"] = \"` ~ name ~ `\";`;
+    static immutable Id = `version (` ~ name ~ `) version_info["ver_`
+         ~ name ~ `"] = "` ~ name ~ `";`;
 }


### PR DESCRIPTION
The original code for this `static immutable` declaration was wrapped in a `mixin("...")`, so the backslashes were necessary to escape the double quote marks.  However, when D1 support (and hence the mixin) was dropped the backslashes were left behind, and now form a part of the `Id` string (meaning the resulting code is not valid D).

Removing these backslashes restores the `Id` string to its correct form.